### PR TITLE
feat(group-details): permitir que cada participante edite sua wishlist

### DIFF
--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/data/exceptions/GroupUpdateException.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/data/exceptions/GroupUpdateException.kt
@@ -1,0 +1,5 @@
+package br.com.brunocarvalhs.group.details.app.data.exceptions
+
+internal data class GroupUpdateException(
+    override val message: String = "Error updating group"
+) : Exception(message)

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/data/model/GroupDetailsDTO.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/data/model/GroupDetailsDTO.kt
@@ -1,9 +1,13 @@
 package br.com.brunocarvalhs.group.details.app.data.model
 
+import br.com.brunocarvalhs.core.domain.extensions.toVanillaMap
 import br.com.brunocarvalhs.core.domain.model.GroupModel
 import br.com.brunocarvalhs.group.details.app.data.constants.EMPTY_STRING
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonObject
 
 @Serializable
 internal data class GroupDetailsDTO(
@@ -38,4 +42,28 @@ internal data class GroupDetailsDTO(
         photo = photoBase64,
         createdAt = createdAt
     )
+
+    fun toMap(): Map<String, Any?> {
+        val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+        return json.encodeToJsonElement(this).jsonObject.toVanillaMap()
+    }
+
+    companion object {
+        fun fromDomain(model: GroupModel) = GroupDetailsDTO(
+            id = model.id,
+            name = model.name,
+            description = model.description,
+            token = model.token,
+            date = model.date,
+            minPrice = model.minPrice,
+            maxPrice = model.maxPrice,
+            type = model.type,
+            photoBase64 = model.photo,
+            members = model.members.map { UserDetailsDTO.fromDomain(it) },
+            draws = model.draws,
+            ownerId = model.ownerId,
+            isOwner = model.isOwner,
+            createdAt = model.createdAt
+        )
+    }
 }

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/data/model/UserDetailsDTO.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/data/model/UserDetailsDTO.kt
@@ -20,4 +20,14 @@ internal data class UserDetailsDTO(
         photoUrl = photoUrl,
         likes = likes
     )
+
+    companion object {
+        fun fromDomain(model: UserModel) = UserDetailsDTO(
+            id = model.id,
+            name = model.name,
+            phoneNumber = model.phoneNumber,
+            photoUrl = model.photoUrl,
+            likes = model.likes
+        )
+    }
 }

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/data/repository/GroupDetailsRepositoryImpl.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/data/repository/GroupDetailsRepositoryImpl.kt
@@ -5,6 +5,7 @@ import br.com.brunocarvalhs.core.network.domain.NetworkService
 import br.com.brunocarvalhs.core.domain.model.GroupModel
 import br.com.brunocarvalhs.group.details.app.data.exceptions.GroupDeleteException
 import br.com.brunocarvalhs.group.details.app.data.exceptions.GroupNotFoundException
+import br.com.brunocarvalhs.group.details.app.data.exceptions.GroupUpdateException
 import br.com.brunocarvalhs.group.details.app.data.model.GroupDetailsDTO
 import br.com.brunocarvalhs.group.details.app.domain.repository.GroupDetailsRepository
 import kotlinx.coroutines.Dispatchers
@@ -36,5 +37,18 @@ internal class GroupDetailsRepositoryImpl @Inject constructor(
         ) ?: throw GroupNotFoundException()
         if (!response) throw GroupDeleteException()
         return@withContext
+    }
+
+    override suspend fun update(group: GroupModel): GroupModel = withContext(Dispatchers.IO) {
+        val dto = GroupDetailsDTO.fromDomain(group)
+        val response = network.make(
+            request = NetworkRequest(
+                endpoint = "${GroupModel.COLLECTION_NAME}/${group.id}",
+                payload = dto.toMap(),
+                method = NetworkService.Method.PUT
+            ),
+            response = GroupDetailsDTO::class
+        ) ?: throw GroupUpdateException()
+        return@withContext response.toDomain()
     }
 }

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/domain/repository/GroupDetailsRepository.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/domain/repository/GroupDetailsRepository.kt
@@ -5,4 +5,5 @@ import br.com.brunocarvalhs.core.domain.model.GroupModel
 internal interface GroupDetailsRepository {
     suspend fun read(groupId: String): GroupModel
     suspend fun delete(group: GroupModel)
+    suspend fun update(group: GroupModel): GroupModel
 }

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/domain/useCases/UpdateMemberLikesUseCase.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/domain/useCases/UpdateMemberLikesUseCase.kt
@@ -1,0 +1,36 @@
+package br.com.brunocarvalhs.group.details.app.domain.useCases
+
+import br.com.brunocarvalhs.core.domain.model.GroupModel
+import br.com.brunocarvalhs.core.domain.model.UserModel
+import br.com.brunocarvalhs.deviceid.DeviceService
+import br.com.brunocarvalhs.group.details.app.domain.repository.GroupDetailsRepository
+import javax.inject.Inject
+
+internal class UpdateMemberLikesUseCase @Inject constructor(
+    private val repository: GroupDetailsRepository,
+    private val deviceService: DeviceService,
+) {
+    suspend operator fun invoke(group: GroupModel, likes: List<String>): Result<GroupModel> =
+        runCatching {
+            val deviceId = deviceService.getDeviceId()
+            val sanitizedLikes = likes.map { it.trim() }.filter { it.isNotBlank() }
+
+            require(group.members.any { it.isCurrentDevice(deviceId) }) {
+                "Current device is not a member of this group"
+            }
+
+            val updatedMembers = group.members.map { member ->
+                if (member.isCurrentDevice(deviceId)) {
+                    member.copy(likes = sanitizedLikes)
+                } else {
+                    member
+                }
+            }
+
+            repository.update(group.copy(members = updatedMembers))
+        }
+
+    private fun UserModel.isCurrentDevice(deviceId: String): Boolean {
+        return id == deviceId || phoneNumber == deviceId
+    }
+}

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsIntent.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsIntent.kt
@@ -5,4 +5,5 @@ internal sealed interface GroupDetailsIntent {
     data class Delete(val callback: () -> Unit) : GroupDetailsIntent
     data object Share : GroupDetailsIntent
     data class Exit(val callback: () -> Unit) : GroupDetailsIntent
+    data class UpdateLikes(val likes: List<String>) : GroupDetailsIntent
 }

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsScreen.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsScreen.kt
@@ -145,7 +145,6 @@ private fun GroupDetailsContent(
     maxPrice: Double?,
     giftType: String?,
     members: List<UserModel>,
-    currentDeviceId: String = "",
     onBack: () -> Unit,
     onDraw: () -> Unit,
     onChat: () -> Unit,
@@ -154,6 +153,7 @@ private fun GroupDetailsContent(
     onShareGroup: () -> Unit,
     onEdit: () -> Unit,
     onAddMembers: () -> Unit,
+    currentDeviceId: String = "",
     onEditLikes: (UserModel) -> Unit = {},
 ) {
     Scaffold(

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsScreen.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsScreen.kt
@@ -38,6 +38,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -56,6 +59,7 @@ import br.com.brunocarvalhs.core.domain.model.GroupModel
 import br.com.brunocarvalhs.core.domain.model.UserModel
 import br.com.brunocarvalhs.group.details.R
 import br.com.brunocarvalhs.group.details.app.presentation.components.ActionIconCard
+import br.com.brunocarvalhs.group.details.app.presentation.components.EditLikesDialog
 import br.com.brunocarvalhs.group.details.app.presentation.components.MemberItem
 import br.com.brunocarvalhs.group.details.app.presentation.components.SectionHeader
 import br.com.brunocarvalhs.group.details.app.presentation.components.SettingItem
@@ -73,6 +77,7 @@ internal fun GroupDetailsScreen(
     val lifecycleOwner = LocalLifecycleOwner.current
     val uiState by viewModel.uiState.collectAsState()
     val group = uiState.group
+    var editingLikesMember by remember { mutableStateOf<UserModel?>(null) }
 
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
@@ -101,6 +106,7 @@ internal fun GroupDetailsScreen(
         maxPrice = group.maxPrice,
         giftType = group.type,
         members = group.members,
+        currentDeviceId = uiState.currentDeviceId,
         onBack = onBack,
         onDraw = { onDraw.invoke(group) },
         onChat = { onChat.invoke(group) },
@@ -108,8 +114,20 @@ internal fun GroupDetailsScreen(
         onShareGroup = { viewModel.handleIntent(GroupDetailsIntent.Share) },
         onExit = { viewModel.handleIntent(GroupDetailsIntent.Exit(onBack)) },
         onEdit = { onEdit.invoke(group) },
-        onAddMembers = { onAddMembers.invoke(group) }
+        onAddMembers = { onAddMembers.invoke(group) },
+        onEditLikes = { member -> editingLikesMember = member }
     )
+
+    editingLikesMember?.let { member ->
+        EditLikesDialog(
+            initialLikes = member.likes,
+            onDismiss = { editingLikesMember = null },
+            onSave = { likes ->
+                viewModel.handleIntent(GroupDetailsIntent.UpdateLikes(likes))
+                editingLikesMember = null
+            }
+        )
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -127,6 +145,7 @@ private fun GroupDetailsContent(
     maxPrice: Double?,
     giftType: String?,
     members: List<UserModel>,
+    currentDeviceId: String = "",
     onBack: () -> Unit,
     onDraw: () -> Unit,
     onChat: () -> Unit,
@@ -135,6 +154,7 @@ private fun GroupDetailsContent(
     onShareGroup: () -> Unit,
     onEdit: () -> Unit,
     onAddMembers: () -> Unit,
+    onEditLikes: (UserModel) -> Unit = {},
 ) {
     Scaffold(
         topBar = {
@@ -197,9 +217,17 @@ private fun GroupDetailsContent(
             }
 
             items(members) { member ->
+                val isCurrentUser = currentDeviceId.isNotBlank() &&
+                    (member.id == currentDeviceId || member.phoneNumber == currentDeviceId)
                 MemberItem(
                     participant = member.name,
+                    likes = member.likes,
                     isAdministrator = isOwner,
+                    onEdit = if (isCurrentUser) {
+                        { onEditLikes(member) }
+                    } else {
+                        null
+                    },
                 )
             }
 

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsUiState.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsUiState.kt
@@ -4,6 +4,7 @@ import br.com.brunocarvalhs.core.domain.model.GroupModel
 
 internal data class GroupDetailsUiState(
     val group: GroupModel,
+    val currentDeviceId: String = "",
     val isLoading: Boolean = false,
     val error: String? = null,
 )

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsViewModel.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsViewModel.kt
@@ -9,10 +9,12 @@ import androidx.navigation.toRoute
 import br.com.brunocarvalhs.core.analytics.AnalyticsService
 import br.com.brunocarvalhs.core.analytics.commons.AnalyticsEvent
 import br.com.brunocarvalhs.core.navigation.routers.GroupDetailsGraph
+import br.com.brunocarvalhs.deviceid.DeviceService
 import br.com.brunocarvalhs.group.details.app.domain.useCases.GroupDeleteUseCase
 import br.com.brunocarvalhs.group.details.app.domain.useCases.GroupExitUseCase
 import br.com.brunocarvalhs.group.details.app.domain.useCases.GroupReadUseCase
 import br.com.brunocarvalhs.group.details.app.domain.useCases.GroupShareUseCase
+import br.com.brunocarvalhs.group.details.app.domain.useCases.UpdateMemberLikesUseCase
 import com.google.firebase.perf.metrics.AddTrace
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -31,11 +33,17 @@ internal class GroupDetailsViewModel @Inject constructor(
     private val deleteUseCase: GroupDeleteUseCase,
     private val exitUseCase: GroupExitUseCase,
     private val shareUseCase: GroupShareUseCase,
+    private val updateMemberLikesUseCase: UpdateMemberLikesUseCase,
+    private val deviceService: DeviceService,
     private val analyticsService: AnalyticsService
 ) : ViewModel() {
     private val args = savedStateHandle.toRoute<GroupDetailsGraph>(GroupDetailsGraph.typeMap)
     private val _uiState = MutableStateFlow(GroupDetailsUiState(group = args.group))
     val uiState: StateFlow<GroupDetailsUiState> = _uiState.asStateFlow()
+
+    init {
+        loadCurrentDeviceId()
+    }
 
     @AddTrace(name = "GroupDetailsViewModel.handleIntent", enabled = true)
     fun handleIntent(intent: GroupDetailsIntent) = when (intent) {
@@ -43,6 +51,34 @@ internal class GroupDetailsViewModel @Inject constructor(
         is GroupDetailsIntent.Delete -> deleteGroup(intent.callback)
         is GroupDetailsIntent.Exit -> exitGroup(intent.callback)
         GroupDetailsIntent.Share -> shareGroup()
+        is GroupDetailsIntent.UpdateLikes -> updateLikes(intent.likes)
+    }
+
+    private fun loadCurrentDeviceId() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(currentDeviceId = deviceService.getDeviceId()) }
+        }
+    }
+
+    @AddTrace(name = "GroupDetailsViewModel.updateLikes", enabled = true)
+    private fun updateLikes(likes: List<String>) {
+        analyticsService.logEvent(
+            name = AnalyticsEvent.SUBMIT,
+            params = mapOf(
+                AnalyticsParam.ACTION to "update_member_likes"
+            )
+        )
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            updateMemberLikesUseCase(_uiState.value.group, likes)
+                .onSuccess { group ->
+                    _uiState.update { it.copy(isLoading = false, group = group) }
+                }
+                .onFailure { error ->
+                    Timber.e(error, "Error updating member likes")
+                    _uiState.update { it.copy(isLoading = false, error = "Erro ao salvar interesses") }
+                }
+        }
     }
 
     @AddTrace(name = "GroupDetailsViewModel.deleteGroup", enabled = true)

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/components/EditLikesDialog.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/components/EditLikesDialog.kt
@@ -1,0 +1,129 @@
+package br.com.brunocarvalhs.group.details.app.presentation.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import br.com.brunocarvalhs.group.details.R
+
+@Composable
+internal fun EditLikesDialog(
+    initialLikes: List<String>,
+    onDismiss: () -> Unit,
+    onSave: (List<String>) -> Unit,
+) {
+    var likes by remember { mutableStateOf(initialLikes) }
+    var input by remember { mutableStateOf("") }
+
+    fun addCurrentInput() {
+        val newLike = input.trim()
+        if (newLike.isNotBlank() && likes.none { it.equals(newLike, ignoreCase = true) }) {
+            likes = likes + newLike
+        }
+        input = ""
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.edit_likes_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(
+                    text = stringResource(R.string.edit_likes_description),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    OutlinedTextField(
+                        value = input,
+                        onValueChange = { input = it },
+                        modifier = Modifier.weight(1f),
+                        placeholder = { Text(stringResource(R.string.edit_likes_add_hint)) },
+                        singleLine = true
+                    )
+                    TextButton(onClick = { addCurrentInput() }, enabled = input.isNotBlank()) {
+                        Text(stringResource(R.string.edit_likes_add_action))
+                    }
+                }
+
+                if (likes.isEmpty()) {
+                    Text(
+                        text = stringResource(R.string.edit_likes_empty_state),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                } else {
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 4.dp),
+                    ) {
+                        items(likes) { like ->
+                            AssistChip(
+                                onClick = {},
+                                label = { Text(like) },
+                                trailingIcon = {
+                                    IconButton(
+                                        modifier = Modifier.padding(0.dp),
+                                        onClick = { likes = likes - like }
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Filled.Close,
+                                            contentDescription = stringResource(
+                                                R.string.edit_likes_remove_action,
+                                                like
+                                            )
+                                        )
+                                    }
+                                },
+                                colors = AssistChipDefaults.assistChipColors(),
+                                modifier = Modifier.padding(vertical = 4.dp)
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = {
+                addCurrentInput()
+                onSave(likes)
+            }) {
+                Text(stringResource(R.string.edit_likes_save_action))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.edit_likes_cancel_action))
+            }
+        }
+    )
+}

--- a/features/group/details/src/main/res/values-es/strings.xml
+++ b/features/group/details/src/main/res/values-es/strings.xml
@@ -30,4 +30,12 @@
     <string name="leave_group">Salir del grupo</string>
     <string name="share_group_message">🎁 ¡Has sido invitado a un Amigo Secreto: %1$s!\n\n📝 Descripción: %2$s\n🔑 Código del grupo: %3$s\n\n¡Descarga la app y únete ahora!</string>
     <string name="share_group_title">Compartir código</string>
+    <string name="edit_likes_title">Tus intereses</string>
+    <string name="edit_likes_description">Añade cosas que te gustan para ayudar a tu amigo invisible a elegir el regalo perfecto.</string>
+    <string name="edit_likes_add_hint">Ej: Libros, Juegos…</string>
+    <string name="edit_likes_add_action">Añadir</string>
+    <string name="edit_likes_save_action">Guardar</string>
+    <string name="edit_likes_cancel_action">Cancelar</string>
+    <string name="edit_likes_remove_action">Eliminar %1$s</string>
+    <string name="edit_likes_empty_state">Aún no se agregaron intereses</string>
 </resources>

--- a/features/group/details/src/main/res/values-ko/strings.xml
+++ b/features/group/details/src/main/res/values-ko/strings.xml
@@ -30,4 +30,12 @@
     <string name="leave_group">그룹 나가기</string>
     <string name="share_group_message">🎁 당신은 시크릿 산타 그룹에 초대되었습니다: %1$s!\n\n📝 설명: %2$s\n🔑 그룹 코드: %3$s\n\n앱을 다운로드하고 지금 참여하세요!</string>
     <string name="share_group_title">코드 공유</string>
+    <string name="edit_likes_title">나의 관심사</string>
+    <string name="edit_likes_description">시크릿 산타가 완벽한 선물을 고를 수 있도록 좋아하는 것을 추가하세요.</string>
+    <string name="edit_likes_add_hint">예: 책, 게임…</string>
+    <string name="edit_likes_add_action">추가</string>
+    <string name="edit_likes_save_action">저장</string>
+    <string name="edit_likes_cancel_action">취소</string>
+    <string name="edit_likes_remove_action">%1$s 삭제</string>
+    <string name="edit_likes_empty_state">아직 추가된 관심사가 없습니다</string>
 </resources>

--- a/features/group/details/src/main/res/values-pt-rBR/strings.xml
+++ b/features/group/details/src/main/res/values-pt-rBR/strings.xml
@@ -30,4 +30,12 @@
     <string name="leave_group">Sair do grupo</string>
     <string name="share_group_message">🎁 Você foi convidado para o Amigo Secreto: %1$s!\n\n📝 Descrição: %2$s\n🔑 Código do grupo: %3$s\n\nBaixe o app e entre agora!</string>
     <string name="share_group_title">Compartilhar Código</string>
+    <string name="edit_likes_title">Seus interesses</string>
+    <string name="edit_likes_description">Adicione coisas que você gosta para ajudar seu amigo secreto a escolher o presente perfeito.</string>
+    <string name="edit_likes_add_hint">Ex: Livros, Jogos…</string>
+    <string name="edit_likes_add_action">Adicionar</string>
+    <string name="edit_likes_save_action">Salvar</string>
+    <string name="edit_likes_cancel_action">Cancelar</string>
+    <string name="edit_likes_remove_action">Remover %1$s</string>
+    <string name="edit_likes_empty_state">Nenhum interesse adicionado ainda</string>
 </resources>

--- a/features/group/details/src/main/res/values/strings.xml
+++ b/features/group/details/src/main/res/values/strings.xml
@@ -30,4 +30,12 @@
     <string name="leave_group">Leave group</string>
     <string name="share_group_message">🎁 You’ve been invited to a Secret Santa group: %1$s!\n\n📝 Description: %2$s\n🔑 Group code: %3$s\n\nDownload the app and join now!</string>
     <string name="share_group_title">Share Code</string>
+    <string name="edit_likes_title">Your wishlist</string>
+    <string name="edit_likes_description">Add things you like to help your Secret Santa pick the perfect gift.</string>
+    <string name="edit_likes_add_hint">E.g. Books, Games…</string>
+    <string name="edit_likes_add_action">Add</string>
+    <string name="edit_likes_save_action">Save</string>
+    <string name="edit_likes_cancel_action">Cancel</string>
+    <string name="edit_likes_remove_action">Remove %1$s</string>
+    <string name="edit_likes_empty_state">No interests added yet</string>
 </resources>

--- a/features/group/details/src/test/java/br/com/brunocarvalhs/group/details/app/data/model/GroupDetailsDTOTest.kt
+++ b/features/group/details/src/test/java/br/com/brunocarvalhs/group/details/app/data/model/GroupDetailsDTOTest.kt
@@ -1,5 +1,7 @@
 package br.com.brunocarvalhs.group.details.app.data.model
 
+import br.com.brunocarvalhs.core.domain.model.GroupModel
+import br.com.brunocarvalhs.core.domain.model.UserModel
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -43,5 +45,60 @@ class GroupDetailsDTOTest {
         assertEquals(dto.ownerId, domain.ownerId)
         assertEquals(dto.isOwner, domain.isOwner)
         assertEquals(dto.createdAt, domain.createdAt)
+    }
+
+    @Test
+    fun `fromDomain should map Domain model to DTO correctly`() {
+        // Given
+        val model = GroupModel(
+            id = "group1",
+            name = "Secret Santa",
+            description = "Fun times",
+            token = "ABC123",
+            date = "2023-12-25",
+            minPrice = 10.0,
+            maxPrice = 50.0,
+            type = "Gift",
+            photo = "base64String",
+            members = listOf(UserModel(id = "user1", name = "Bruno", likes = listOf("Coding"))),
+            draws = mapOf("user1" to "user2"),
+            ownerId = "owner123",
+            isOwner = true,
+            createdAt = 123456789L
+        )
+
+        // When
+        val dto = GroupDetailsDTO.fromDomain(model)
+
+        // Then
+        assertEquals(model.id, dto.id)
+        assertEquals(model.name, dto.name)
+        assertEquals(model.description, dto.description)
+        assertEquals(model.token, dto.token)
+        assertEquals(model.date, dto.date)
+        assertEquals(model.minPrice, dto.minPrice)
+        assertEquals(model.maxPrice, dto.maxPrice)
+        assertEquals(model.type, dto.type)
+        assertEquals(model.photo, dto.photoBase64)
+        assertEquals(model.members.size, dto.members.size)
+        assertEquals(model.members.first().likes, dto.members.first().likes)
+        assertEquals(model.draws, dto.draws)
+        assertEquals(model.ownerId, dto.ownerId)
+        assertEquals(model.isOwner, dto.isOwner)
+        assertEquals(model.createdAt, dto.createdAt)
+    }
+
+    @Test
+    fun `toMap should serialize DTO fields`() {
+        // Given
+        val dto = GroupDetailsDTO(id = "group1", name = "Secret Santa", token = "ABC123")
+
+        // When
+        val map = dto.toMap()
+
+        // Then
+        assertEquals("group1", map[GroupModel.ID])
+        assertEquals("Secret Santa", map[GroupModel.NAME])
+        assertEquals("ABC123", map[GroupModel.TOKEN])
     }
 }

--- a/features/group/details/src/test/java/br/com/brunocarvalhs/group/details/app/data/model/UserDetailsDTOTest.kt
+++ b/features/group/details/src/test/java/br/com/brunocarvalhs/group/details/app/data/model/UserDetailsDTOTest.kt
@@ -1,5 +1,6 @@
 package br.com.brunocarvalhs.group.details.app.data.model
 
+import br.com.brunocarvalhs.core.domain.model.UserModel
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -25,5 +26,27 @@ class UserDetailsDTOTest {
         assertEquals(dto.phoneNumber, domain.phoneNumber)
         assertEquals(dto.photoUrl, domain.photoUrl)
         assertEquals(dto.likes, domain.likes)
+    }
+
+    @Test
+    fun `fromDomain should map Domain model to DTO correctly`() {
+        // Given
+        val model = UserModel(
+            id = "user1",
+            name = "Bruno",
+            phoneNumber = "123456",
+            photoUrl = "http://photo.com",
+            likes = listOf("Coding", "Games")
+        )
+
+        // When
+        val dto = UserDetailsDTO.fromDomain(model)
+
+        // Then
+        assertEquals(model.id, dto.id)
+        assertEquals(model.name, dto.name)
+        assertEquals(model.phoneNumber, dto.phoneNumber)
+        assertEquals(model.photoUrl, dto.photoUrl)
+        assertEquals(model.likes, dto.likes)
     }
 }

--- a/features/group/details/src/test/java/br/com/brunocarvalhs/group/details/app/data/repository/GroupDetailsRepositoryImplTest.kt
+++ b/features/group/details/src/test/java/br/com/brunocarvalhs/group/details/app/data/repository/GroupDetailsRepositoryImplTest.kt
@@ -4,6 +4,7 @@ import br.com.brunocarvalhs.core.network.domain.NetworkRequest
 import br.com.brunocarvalhs.core.network.domain.NetworkService
 import br.com.brunocarvalhs.core.domain.model.GroupModel
 import br.com.brunocarvalhs.group.details.app.data.exceptions.GroupNotFoundException
+import br.com.brunocarvalhs.group.details.app.data.exceptions.GroupUpdateException
 import br.com.brunocarvalhs.group.details.app.data.model.GroupDetailsDTO
 import io.mockk.coEvery
 import io.mockk.mockk
@@ -81,5 +82,44 @@ class GroupDetailsRepositoryImplTest {
         repository.delete(group)
 
         // Then - Should not throw exception
+    }
+
+    @Test
+    fun `update should return updated group when network succeeds`() = runTest {
+        // Given
+        val group = GroupModel(id = "1", name = "Updated")
+        val dto = GroupDetailsDTO(id = "1", name = "Updated")
+        coEvery {
+            network.make(
+                request = match {
+                    it.endpoint == "groups/1" && it.method == NetworkService.Method.PUT
+                },
+                response = GroupDetailsDTO::class
+            )
+        } returns dto
+
+        // When
+        val result = repository.update(group)
+
+        // Then
+        assertEquals("1", result.id)
+        assertEquals("Updated", result.name)
+    }
+
+    @Test(expected = GroupUpdateException::class)
+    fun `update should throw exception when network returns null`() = runTest {
+        // Given
+        val group = GroupModel(id = "1", name = "Updated")
+        coEvery {
+            network.make(
+                request = match {
+                    it.endpoint == "groups/1" && it.method == NetworkService.Method.PUT
+                },
+                response = GroupDetailsDTO::class
+            )
+        } returns null
+
+        // When
+        repository.update(group)
     }
 }

--- a/features/group/details/src/test/java/br/com/brunocarvalhs/group/details/app/domain/useCases/UpdateMemberLikesUseCaseTest.kt
+++ b/features/group/details/src/test/java/br/com/brunocarvalhs/group/details/app/domain/useCases/UpdateMemberLikesUseCaseTest.kt
@@ -1,0 +1,81 @@
+package br.com.brunocarvalhs.group.details.app.domain.useCases
+
+import br.com.brunocarvalhs.core.domain.model.GroupModel
+import br.com.brunocarvalhs.core.domain.model.UserModel
+import br.com.brunocarvalhs.deviceid.DeviceService
+import br.com.brunocarvalhs.group.details.app.domain.repository.GroupDetailsRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class UpdateMemberLikesUseCaseTest {
+
+    private val repository: GroupDetailsRepository = mockk()
+    private val deviceService: DeviceService = mockk()
+    private lateinit var useCase: UpdateMemberLikesUseCase
+
+    @Before
+    fun setup() {
+        useCase = UpdateMemberLikesUseCase(repository, deviceService)
+    }
+
+    @Test
+    fun `invoke should update likes of the current device member`() = runTest {
+        // Given
+        val self = UserModel(id = "device-1", name = "Bruno", likes = emptyList())
+        val other = UserModel(id = "device-2", name = "Isabella", likes = listOf("Music"))
+        val group = GroupModel(id = "group-1", members = listOf(self, other))
+        val newLikes = listOf("Books", " Games ", "")
+
+        coEvery { deviceService.getDeviceId() } returns "device-1"
+        coEvery { repository.update(any()) } answers { firstArg() }
+
+        // When
+        val result = useCase(group, newLikes)
+
+        // Then
+        assertTrue(result.isSuccess)
+        val updatedGroup = result.getOrThrow()
+        assertEquals(listOf("Books", "Games"), updatedGroup.members.first { it.id == "device-1" }.likes)
+        assertEquals(listOf("Music"), updatedGroup.members.first { it.id == "device-2" }.likes)
+        coVerify { repository.update(any()) }
+    }
+
+    @Test
+    fun `invoke should match member by phoneNumber when id differs from device id`() = runTest {
+        // Given
+        val self = UserModel(id = "user-uuid", phoneNumber = "device-1", name = "Bruno")
+        val group = GroupModel(id = "group-1", members = listOf(self))
+
+        coEvery { deviceService.getDeviceId() } returns "device-1"
+        coEvery { repository.update(any()) } answers { firstArg() }
+
+        // When
+        val result = useCase(group, listOf("Coffee"))
+
+        // Then
+        assertTrue(result.isSuccess)
+        assertEquals(listOf("Coffee"), result.getOrThrow().members.first().likes)
+    }
+
+    @Test
+    fun `invoke should fail when current device is not a member of the group`() = runTest {
+        // Given
+        val other = UserModel(id = "device-2", name = "Isabella")
+        val group = GroupModel(id = "group-1", members = listOf(other))
+
+        coEvery { deviceService.getDeviceId() } returns "device-1"
+
+        // When
+        val result = useCase(group, listOf("Books"))
+
+        // Then
+        assertTrue(result.isFailure)
+        coVerify(inverse = true) { repository.update(any()) }
+    }
+}


### PR DESCRIPTION
## Resumo
- Conecta os slots `likes`/`onEdit` do `MemberItem` (já existiam no componente, mas não eram usados) para que cada participante possa adicionar/remover itens da própria wishlist (`UserModel.likes`).
- Identifica "o membro atual" reaproveitando o mesmo padrão de match por `deviceId`/`phoneNumber` já usado em `ChatViewModel`; só o próprio dispositivo pode editar sua entrada.
- Adiciona `GroupDetailsRepository.update()` + `GroupDetailsDTO/UserDetailsDTO.fromDomain()`, espelhando o padrão já usado em `features:group:create` (`GroupCreateDTO`/`GroupCreateRepositoryImpl`).
- Novo `UpdateMemberLikesUseCase` e novo diálogo `EditLikesDialog` (Material3 `AlertDialog` + `AssistChip`).
- Strings adicionadas nos 4 idiomas já suportados pelo módulo (en, pt-BR, es, ko).

## Escopo
Restrito ao módulo `features:group:details`, sem alterações em outros módulos.

## Test plan
- [x] `./gradlew :features:group:details:compileDebugKotlin` — sem erros
- [x] `./gradlew :features:group:details:testDebugUnitTest` — todos os testes passando, incluindo os novos (`UpdateMemberLikesUseCaseTest`, `GroupDetailsRepositoryImplTest#update`, DTO `fromDomain`)
- [ ] `detekt` não pôde ser validado neste ambiente (JDK 25 incompatível com o `jvmTarget` do detekt configurado no projeto — problema pré-existente do toolchain local, não relacionado a este diff)
- [ ] Teste manual em emulador/dispositivo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2XxUMSoZ4SVLZnBmydQhy