### PR TITLE
feat(group-details): compartilhar a lista de desejos por texto

### DIFF
--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/domain/useCases/ShareWishlistUseCase.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/domain/useCases/ShareWishlistUseCase.kt
@@ -1,0 +1,56 @@
+package br.com.brunocarvalhs.group.details.app.domain.useCases
+
+import android.content.Context
+import android.content.Intent
+import br.com.brunocarvalhs.core.domain.model.GroupModel
+import br.com.brunocarvalhs.core.domain.model.UserModel
+import br.com.brunocarvalhs.deviceid.DeviceService
+import br.com.brunocarvalhs.group.details.R
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+internal class ShareWishlistUseCase @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+    private val deviceService: DeviceService,
+) {
+    suspend operator fun invoke(group: GroupModel): Result<Unit> = runCatching {
+        val deviceId = deviceService.getDeviceId()
+        val self = group.members.firstOrNull { it.isCurrentDevice(deviceId) }
+            ?: throw MemberNotFoundException()
+        val likes = self.likes.filter { it.isNotBlank() }
+        if (likes.isEmpty()) throw EmptyWishlistException()
+
+        val message = context.getString(
+            R.string.share_wishlist_message,
+            group.name,
+            likes.joinToString(separator = "\n") { "• $it" }
+        )
+
+        val sendIntent = Intent().apply {
+            action = Intent.ACTION_SEND
+            putExtra(Intent.EXTRA_TEXT, message)
+            type = TYPE
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+
+        val shareIntent = Intent.createChooser(
+            sendIntent,
+            context.getString(R.string.share_wishlist_title)
+        ).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+
+        context.startActivity(shareIntent)
+    }
+
+    private fun UserModel.isCurrentDevice(deviceId: String): Boolean {
+        return id == deviceId || phoneNumber == deviceId
+    }
+
+    internal class MemberNotFoundException : Exception("Current device is not a member of this group")
+    internal class EmptyWishlistException : Exception("There are no wishlist items to share")
+
+    companion object {
+        private const val TYPE = "text/plain"
+    }
+}

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsIntent.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsIntent.kt
@@ -4,5 +4,6 @@ internal sealed interface GroupDetailsIntent {
     data object Refresh : GroupDetailsIntent
     data class Delete(val callback: () -> Unit) : GroupDetailsIntent
     data object Share : GroupDetailsIntent
+    data object ShareWishlist : GroupDetailsIntent
     data class Exit(val callback: () -> Unit) : GroupDetailsIntent
 }

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsScreen.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsScreen.kt
@@ -108,7 +108,8 @@ internal fun GroupDetailsScreen(
         onShareGroup = { viewModel.handleIntent(GroupDetailsIntent.Share) },
         onExit = { viewModel.handleIntent(GroupDetailsIntent.Exit(onBack)) },
         onEdit = { onEdit.invoke(group) },
-        onAddMembers = { onAddMembers.invoke(group) }
+        onAddMembers = { onAddMembers.invoke(group) },
+        onShareWishlist = { viewModel.handleIntent(GroupDetailsIntent.ShareWishlist) }
     )
 }
 
@@ -135,6 +136,7 @@ private fun GroupDetailsContent(
     onShareGroup: () -> Unit,
     onEdit: () -> Unit,
     onAddMembers: () -> Unit,
+    onShareWishlist: () -> Unit = {},
 ) {
     Scaffold(
         topBar = {
@@ -208,7 +210,8 @@ private fun GroupDetailsContent(
                     isOwner = isOwner,
                     onEdit = onEdit,
                     onDelete = onDelete,
-                    onExit = onExit
+                    onExit = onExit,
+                    onShareWishlist = onShareWishlist
                 )
             }
         }
@@ -398,10 +401,16 @@ private fun GroupDetailsFooter(
     isOwner: Boolean,
     onEdit: () -> Unit,
     onDelete: () -> Unit,
-    onExit: () -> Unit
+    onExit: () -> Unit,
+    onShareWishlist: () -> Unit = {}
 ) {
     Column {
         HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp), thickness = 0.5.dp)
+        SettingItem(
+            Icons.Default.CardGiftcard,
+            stringResource(R.string.share_wishlist_action),
+            onClick = onShareWishlist
+        )
         if (isOwner) {
             SettingItem(
                 Icons.Default.Edit,

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsViewModel.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsViewModel.kt
@@ -13,6 +13,7 @@ import br.com.brunocarvalhs.group.details.app.domain.useCases.GroupDeleteUseCase
 import br.com.brunocarvalhs.group.details.app.domain.useCases.GroupExitUseCase
 import br.com.brunocarvalhs.group.details.app.domain.useCases.GroupReadUseCase
 import br.com.brunocarvalhs.group.details.app.domain.useCases.GroupShareUseCase
+import br.com.brunocarvalhs.group.details.app.domain.useCases.ShareWishlistUseCase
 import com.google.firebase.perf.metrics.AddTrace
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -31,6 +32,7 @@ internal class GroupDetailsViewModel @Inject constructor(
     private val deleteUseCase: GroupDeleteUseCase,
     private val exitUseCase: GroupExitUseCase,
     private val shareUseCase: GroupShareUseCase,
+    private val shareWishlistUseCase: ShareWishlistUseCase,
     private val analyticsService: AnalyticsService
 ) : ViewModel() {
     private val args = savedStateHandle.toRoute<GroupDetailsGraph>(GroupDetailsGraph.typeMap)
@@ -43,6 +45,7 @@ internal class GroupDetailsViewModel @Inject constructor(
         is GroupDetailsIntent.Delete -> deleteGroup(intent.callback)
         is GroupDetailsIntent.Exit -> exitGroup(intent.callback)
         GroupDetailsIntent.Share -> shareGroup()
+        GroupDetailsIntent.ShareWishlist -> shareWishlist()
     }
 
     @AddTrace(name = "GroupDetailsViewModel.deleteGroup", enabled = true)
@@ -99,6 +102,23 @@ internal class GroupDetailsViewModel @Inject constructor(
         )
         viewModelScope.launch {
             shareUseCase(group = _uiState.value.group)
+        }
+    }
+
+    @AddTrace(name = "GroupDetailsViewModel.shareWishlist", enabled = true)
+    private fun shareWishlist() {
+        analyticsService.logEvent(
+            name = AnalyticsEvent.SUBMIT,
+            params = mapOf(
+                AnalyticsParam.ACTION to "share_wishlist"
+            )
+        )
+        viewModelScope.launch {
+            shareWishlistUseCase(group = _uiState.value.group)
+                .onFailure { error ->
+                    Timber.e(error, "Error sharing wishlist")
+                    _uiState.update { it.copy(error = "Adicione itens à sua lista antes de compartilhar") }
+                }
         }
     }
 

--- a/features/group/details/src/main/res/values-es/strings.xml
+++ b/features/group/details/src/main/res/values-es/strings.xml
@@ -30,4 +30,7 @@
     <string name="leave_group">Salir del grupo</string>
     <string name="share_group_message">🎁 ¡Has sido invitado a un Amigo Secreto: %1$s!\n\n📝 Descripción: %2$s\n🔑 Código del grupo: %3$s\n\n¡Descarga la app y únete ahora!</string>
     <string name="share_group_title">Compartir código</string>
+    <string name="share_wishlist_action">Compartir mi lista de deseos</string>
+    <string name="share_wishlist_title">Compartir Lista de Deseos</string>
+    <string name="share_wishlist_message">🎁 Aquí está mi lista de deseos para el Amigo Invisible %1$s:\n\n%2$s</string>
 </resources>

--- a/features/group/details/src/main/res/values-ko/strings.xml
+++ b/features/group/details/src/main/res/values-ko/strings.xml
@@ -30,4 +30,7 @@
     <string name="leave_group">그룹 나가기</string>
     <string name="share_group_message">🎁 당신은 시크릿 산타 그룹에 초대되었습니다: %1$s!\n\n📝 설명: %2$s\n🔑 그룹 코드: %3$s\n\n앱을 다운로드하고 지금 참여하세요!</string>
     <string name="share_group_title">코드 공유</string>
+    <string name="share_wishlist_action">내 위시리스트 공유</string>
+    <string name="share_wishlist_title">위시리스트 공유</string>
+    <string name="share_wishlist_message">🎁 시크릿 산타 그룹 %1$s를 위한 제 위시리스트입니다:\n\n%2$s</string>
 </resources>

--- a/features/group/details/src/main/res/values-pt-rBR/strings.xml
+++ b/features/group/details/src/main/res/values-pt-rBR/strings.xml
@@ -30,4 +30,7 @@
     <string name="leave_group">Sair do grupo</string>
     <string name="share_group_message">🎁 Você foi convidado para o Amigo Secreto: %1$s!\n\n📝 Descrição: %2$s\n🔑 Código do grupo: %3$s\n\nBaixe o app e entre agora!</string>
     <string name="share_group_title">Compartilhar Código</string>
+    <string name="share_wishlist_action">Compartilhar minha lista de desejos</string>
+    <string name="share_wishlist_title">Compartilhar Lista de Desejos</string>
+    <string name="share_wishlist_message">🎁 Aqui está minha lista de desejos para o Amigo Secreto %1$s:\n\n%2$s</string>
 </resources>

--- a/features/group/details/src/main/res/values/strings.xml
+++ b/features/group/details/src/main/res/values/strings.xml
@@ -30,4 +30,7 @@
     <string name="leave_group">Leave group</string>
     <string name="share_group_message">🎁 You’ve been invited to a Secret Santa group: %1$s!\n\n📝 Description: %2$s\n🔑 Group code: %3$s\n\nDownload the app and join now!</string>
     <string name="share_group_title">Share Code</string>
+    <string name="share_wishlist_action">Share my wishlist</string>
+    <string name="share_wishlist_title">Share Wishlist</string>
+    <string name="share_wishlist_message">🎁 Here’s my wishlist for the Secret Santa group %1$s:\n\n%2$s</string>
 </resources>

--- a/features/group/details/src/test/java/br/com/brunocarvalhs/group/details/app/domain/useCases/ShareWishlistUseCaseTest.kt
+++ b/features/group/details/src/test/java/br/com/brunocarvalhs/group/details/app/domain/useCases/ShareWishlistUseCaseTest.kt
@@ -1,0 +1,71 @@
+package br.com.brunocarvalhs.group.details.app.domain.useCases
+
+import android.content.Context
+import br.com.brunocarvalhs.core.domain.model.GroupModel
+import br.com.brunocarvalhs.core.domain.model.UserModel
+import br.com.brunocarvalhs.deviceid.DeviceService
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ShareWishlistUseCaseTest {
+
+    private val context: Context = mockk(relaxed = true)
+    private val deviceService: DeviceService = mockk()
+    private lateinit var useCase: ShareWishlistUseCase
+
+    @Before
+    fun setup() {
+        every { context.getString(any(), *anyVararg()) } returns "message"
+        useCase = ShareWishlistUseCase(context, deviceService)
+    }
+
+    @Test
+    fun `invoke should start share intent when current member has likes`() = runTest {
+        // Given
+        val self = UserModel(id = "device-1", name = "Bruno", likes = listOf("Books", "Games"))
+        val group = GroupModel(id = "group-1", name = "Family", members = listOf(self))
+        coEvery { deviceService.getDeviceId() } returns "device-1"
+
+        // When
+        val result = useCase(group)
+
+        // Then
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `invoke should fail when current member has no likes`() = runTest {
+        // Given
+        val self = UserModel(id = "device-1", name = "Bruno", likes = emptyList())
+        val group = GroupModel(id = "group-1", members = listOf(self))
+        coEvery { deviceService.getDeviceId() } returns "device-1"
+
+        // When
+        val result = useCase(group)
+
+        // Then
+        assertTrue(result.exceptionOrNull() is ShareWishlistUseCase.EmptyWishlistException)
+    }
+
+    @Test
+    fun `invoke should fail when current device is not a member`() = runTest {
+        // Given
+        val other = UserModel(id = "device-2", name = "Isabella", likes = listOf("Music"))
+        val group = GroupModel(id = "group-1", members = listOf(other))
+        coEvery { deviceService.getDeviceId() } returns "device-1"
+
+        // When
+        val result = useCase(group)
+
+        // Then
+        assertTrue(result.exceptionOrNull() is ShareWishlistUseCase.MemberNotFoundException)
+    }
+}


### PR DESCRIPTION
## Resumo
- Novo `ShareWishlistUseCase`, espelhando o padrão já usado em `GroupShareUseCase`/`ShareSecretFriendsUseCase` (`Intent.ACTION_SEND` + `Intent.createChooser`).
- Identifica o membro atual pelo mesmo padrão de match por `deviceId`/`phoneNumber` do `ChatViewModel`, monta a mensagem a partir de `UserModel.likes` e falha com uma mensagem de erro amigável se a lista estiver vazia.
- Nova ação "Compartilhar minha lista de desejos" no rodapé de `GroupDetailsScreen`, disponível para qualquer participante (não só o dono do grupo).
- Strings adicionadas nos 4 idiomas já suportados pelo módulo (en, pt-BR, es, ko).

## Escopo
Restrito ao módulo `features:group:details`. Independente da PR #58 (edição da wishlist) — funciona com os likes que já existirem no membro, mesmo sem aquela PR.

## Test plan
- [x] `./gradlew :features:group:details:compileDebugKotlin` — sem erros
- [x] `./gradlew :features:group:details:testDebugUnitTest` — suíte completa passando, incluindo `ShareWishlistUseCaseTest` (Robolectric, mesmo padrão do `GroupShareUseCaseTest`)
- [ ] `detekt` não pôde ser validado neste ambiente (JDK 25 incompatível com o `jvmTarget` do detekt configurado no projeto — problema pré-existente do toolchain local)
- [ ] Teste manual em emulador/dispositivo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2XxUMSoZ4SVLZnBmydQhy