### PR TITLE
feat(chat): reações rápidas em emoji nas mensagens do chat anônimo

### DIFF
--- a/core/domain/src/main/java/br/com/brunocarvalhs/core/domain/model/MessageModel.kt
+++ b/core/domain/src/main/java/br/com/brunocarvalhs/core/domain/model/MessageModel.kt
@@ -7,7 +7,8 @@ data class MessageModel(
     val senderId: String = "",
     val senderName: String = "",
     val timestamp: Long = System.currentTimeMillis(),
-    val status: MessageStatus = MessageStatus.SENT
+    val status: MessageStatus = MessageStatus.SENT,
+    val reactions: Map<String, String> = emptyMap()
 ) {
     enum class MessageStatus {
         SENDING, SENT, ERROR

--- a/core/domain/src/test/java/br/com/brunocarvalhs/core/domain/model/MessageModelTest.kt
+++ b/core/domain/src/test/java/br/com/brunocarvalhs/core/domain/model/MessageModelTest.kt
@@ -18,6 +18,7 @@ class MessageModelTest {
 
         assertTrue(message.timestamp > 0)
         assertEquals(MessageModel.MessageStatus.SENT, message.status)
+        assertTrue(message.reactions.isEmpty())
     }
 
     @Test
@@ -80,5 +81,14 @@ class MessageModelTest {
         val after = System.currentTimeMillis()
 
         assertTrue(message.timestamp in before..after)
+    }
+
+    @Test
+    fun shouldSupportReactionsPerDevice() {
+        val message = MessageModel(reactions = mapOf("device-1" to "👍", "device-2" to "❤️"))
+
+        assertEquals(2, message.reactions.size)
+        assertEquals("👍", message.reactions["device-1"])
+        assertEquals("❤️", message.reactions["device-2"])
     }
 }

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/data/local/ChatDatabase.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/data/local/ChatDatabase.kt
@@ -2,9 +2,11 @@ package br.com.brunocarvalhs.chat.app.data.local
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
 import br.com.brunocarvalhs.chat.app.data.model.ChatMessage
 
-@Database(entities = [ChatMessage::class], version = 2, exportSchema = false)
+@Database(entities = [ChatMessage::class], version = 3, exportSchema = false)
+@TypeConverters(ReactionsConverter::class)
 abstract class ChatDatabase : RoomDatabase() {
     abstract fun chatMessageDao(): ChatMessageDao
 }

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/data/local/ReactionsConverter.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/data/local/ReactionsConverter.kt
@@ -1,0 +1,20 @@
+package br.com.brunocarvalhs.chat.app.data.local
+
+import androidx.room.TypeConverter
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+internal class ReactionsConverter {
+
+    @TypeConverter
+    fun fromReactions(reactions: Map<String, String>): String {
+        return Json.encodeToString(reactions)
+    }
+
+    @TypeConverter
+    fun toReactions(value: String): Map<String, String> {
+        return runCatching { Json.decodeFromString<Map<String, String>>(value) }
+            .getOrDefault(emptyMap())
+    }
+}

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/data/model/ChatMessage.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/data/model/ChatMessage.kt
@@ -14,5 +14,6 @@ data class ChatMessage(
     val timestamp: Long = System.currentTimeMillis(),
     val senderName: String = "",
     val senderId: String = "",
-    val status: MessageModel.MessageStatus = MessageModel.MessageStatus.SENT
+    val status: MessageModel.MessageStatus = MessageModel.MessageStatus.SENT,
+    val reactions: Map<String, String> = emptyMap()
 )

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/data/repository/ChatRepositoryImpl.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/data/repository/ChatRepositoryImpl.kt
@@ -21,4 +21,13 @@ class ChatRepositoryImpl @Inject constructor(
     override suspend fun clearMessages(groupId: String): Result<Unit> {
         return chatService.clearMessages(groupId)
     }
+
+    override suspend fun setReaction(
+        groupId: String,
+        messageId: String,
+        deviceId: String,
+        emoji: String?
+    ): Result<Unit> {
+        return chatService.setReaction(groupId, messageId, deviceId, emoji)
+    }
 }

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/data/services/FirebaseRealtimeManager.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/data/services/FirebaseRealtimeManager.kt
@@ -82,9 +82,28 @@ class FirebaseRealtimeManager @Inject constructor(
         database.getReference(PATH).child(groupId).removeValue().await()
     }
 
+    override suspend fun setReaction(
+        groupId: String,
+        messageId: String,
+        deviceId: String,
+        emoji: String?
+    ): Result<Unit> = runCatching {
+        val reference = database.getReference(PATH).child(groupId).child(messageId)
+            .child(KEY_REACTIONS).child(deviceId)
+
+        if (emoji.isNullOrBlank()) {
+            reference.removeValue().await()
+        } else {
+            reference.setValue(emoji).await()
+        }
+    }
+
     private fun Map<String, Any>.toMessageModel(key: String, groupId: String): MessageModel {
         val statusOrdinal = (this[KEY_STATUS] as? Long)?.toInt() ?: MessageStatus.SENT.ordinal
         val status = MessageStatus.entries.getOrElse(statusOrdinal) { MessageStatus.SENT }
+
+        @Suppress("UNCHECKED_CAST")
+        val reactions = (this[KEY_REACTIONS] as? Map<String, String>) ?: emptyMap()
 
         return MessageModel(
             id = key,
@@ -93,7 +112,8 @@ class FirebaseRealtimeManager @Inject constructor(
             senderId = this[KEY_SENDER_ID] as? String ?: EMPTY_STRING,
             senderName = this[KEY_SENDER_NAME] as? String ?: EMPTY_STRING,
             timestamp = (this[KEY_TIMESTAMP] as? Long) ?: System.currentTimeMillis(),
-            status = status
+            status = status,
+            reactions = reactions
         )
     }
 
@@ -104,6 +124,7 @@ class FirebaseRealtimeManager @Inject constructor(
         const val KEY_SENDER_NAME = "sn"
         const val KEY_TIMESTAMP = "ts"
         const val KEY_STATUS = "s"
+        const val KEY_REACTIONS = "r"
         const val LIMIT_TO_LAST = 20
         const val EMPTY_STRING = ""
     }

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/domain/repository/ChatRepository.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/domain/repository/ChatRepository.kt
@@ -7,4 +7,10 @@ interface ChatRepository {
     suspend fun getMessages(groupId: String): Flow<List<MessageModel>>
     suspend fun sendMessage(groupId: String, message: MessageModel): Result<Unit>
     suspend fun clearMessages(groupId: String): Result<Unit>
+    suspend fun setReaction(
+        groupId: String,
+        messageId: String,
+        deviceId: String,
+        emoji: String?
+    ): Result<Unit>
 }

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/domain/services/ChatService.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/domain/services/ChatService.kt
@@ -7,4 +7,10 @@ interface ChatService {
     fun getMessages(groupId: String): Flow<List<MessageModel>>
     suspend fun sendMessage(groupId: String, message: MessageModel): Result<Unit>
     suspend fun clearMessages(groupId: String): Result<Unit>
+    suspend fun setReaction(
+        groupId: String,
+        messageId: String,
+        deviceId: String,
+        emoji: String?
+    ): Result<Unit>
 }

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/domain/usecase/ToggleMessageReactionUseCase.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/domain/usecase/ToggleMessageReactionUseCase.kt
@@ -1,0 +1,21 @@
+package br.com.brunocarvalhs.chat.app.domain.usecase
+
+import br.com.brunocarvalhs.chat.app.domain.repository.ChatRepository
+import com.google.firebase.perf.metrics.AddTrace
+import javax.inject.Inject
+
+class ToggleMessageReactionUseCase @Inject constructor(
+    private val repository: ChatRepository
+) {
+    @AddTrace(name = "ToggleMessageReactionUseCase.invoke", enabled = true)
+    suspend operator fun invoke(
+        groupId: String,
+        messageId: String,
+        deviceId: String,
+        currentReactions: Map<String, String>,
+        emoji: String
+    ): Result<Unit> {
+        val newValue = if (currentReactions[deviceId] == emoji) null else emoji
+        return repository.setReaction(groupId, messageId, deviceId, newValue)
+    }
+}

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/ChatIntent.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/ChatIntent.kt
@@ -7,4 +7,5 @@ internal sealed class ChatIntent {
     object ClearChat : ChatIntent()
     data class IdentifyUser(val name: String) : ChatIntent()
     object DismissIdentification : ChatIntent()
+    data class ToggleReaction(val messageId: String, val emoji: String) : ChatIntent()
 }

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/ChatScreen.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/ChatScreen.kt
@@ -1,5 +1,6 @@
 package br.com.brunocarvalhs.chat.app.presentation
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -20,10 +21,13 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.AccessTime
+import androidx.compose.material.icons.filled.AddReaction
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -59,6 +63,8 @@ import br.com.brunocarvalhs.chat.R
 import br.com.brunocarvalhs.chat.app.data.extensions.toLocalDateTime
 import br.com.brunocarvalhs.chat.app.data.model.ChatMessage
 import br.com.brunocarvalhs.core.domain.model.MessageModel.MessageStatus
+
+private val QUICK_REACTIONS = listOf("👍", "❤️", "😂", "🎁", "😮")
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -120,7 +126,12 @@ internal fun ChatScreen(
                 contentPadding = PaddingValues(16.dp)
             ) {
                 items(state.messages, key = { it.id }) { message ->
-                    ChatMessageItem(message)
+                    ChatMessageItem(
+                        message = message,
+                        onToggleReaction = { emoji ->
+                            viewModel.handleIntent(ChatIntent.ToggleReaction(message.id, emoji))
+                        }
+                    )
                 }
             }
         }
@@ -173,64 +184,135 @@ fun IdentificationDialog(
 @Composable
 fun ChatMessageItem(
     message: ChatMessage,
+    onToggleReaction: (String) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
+    var showReactionPicker by remember { mutableStateOf(false) }
     val alignment = if (message.isFromMe) Alignment.CenterEnd else Alignment.CenterStart
     val containerColor =
-        if (message.isFromMe) MaterialTheme.colorScheme.primaryContainer 
+        if (message.isFromMe) MaterialTheme.colorScheme.primaryContainer
         else MaterialTheme.colorScheme.secondaryContainer
-    
+
     val shape = if (message.isFromMe) {
         RoundedCornerShape(16.dp, 16.dp, 0.dp, 16.dp)
     } else {
         RoundedCornerShape(16.dp, 16.dp, 16.dp, 0.dp)
     }
 
-    Box(
+    Column(
         modifier = modifier
             .fillMaxWidth()
             .padding(vertical = 4.dp),
-        contentAlignment = alignment
+        horizontalAlignment = if (message.isFromMe) Alignment.End else Alignment.Start
     ) {
-        Card(
-            shape = shape,
-            colors = CardDefaults.cardColors(containerColor = containerColor),
-            modifier = Modifier.widthIn(max = 280.dp)
+        Box(
+            modifier = Modifier.fillMaxWidth(),
+            contentAlignment = alignment
         ) {
-            Column(modifier = Modifier.padding(12.dp)) {
-                if (!message.isFromMe) {
-                    Text(
-                        text = message.senderName,
-                        style = MaterialTheme.typography.labelMedium.copy(
-                            fontWeight = FontWeight.Bold,
-                            fontSize = 12.sp
-                        ),
-                        color = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.padding(bottom = 4.dp)
-                    )
-                }
+            Card(
+                shape = shape,
+                colors = CardDefaults.cardColors(containerColor = containerColor),
+                modifier = Modifier.widthIn(max = 280.dp)
+            ) {
+                Column(modifier = Modifier.padding(12.dp)) {
+                    if (!message.isFromMe) {
+                        Text(
+                            text = message.senderName,
+                            style = MaterialTheme.typography.labelMedium.copy(
+                                fontWeight = FontWeight.Bold,
+                                fontSize = 12.sp
+                            ),
+                            color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.padding(bottom = 4.dp)
+                        )
+                    }
 
-                Text(
-                    text = message.text, 
-                    style = MaterialTheme.typography.bodyLarge
-                )
-                
-                Row(
-                    modifier = Modifier.align(Alignment.End),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
                     Text(
-                        text = message.timestamp.toLocalDateTime(),
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.outline
+                        text = message.text,
+                        style = MaterialTheme.typography.bodyLarge
                     )
-                    
-                    if (message.isFromMe) {
+
+                    Row(
+                        modifier = Modifier.align(Alignment.End),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        IconButton(
+                            onClick = { showReactionPicker = !showReactionPicker },
+                            modifier = Modifier.size(20.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.AddReaction,
+                                contentDescription = stringResource(R.string.react_to_message),
+                                modifier = Modifier.size(16.dp),
+                                tint = MaterialTheme.colorScheme.outline
+                            )
+                        }
                         Spacer(modifier = Modifier.width(4.dp))
-                        StatusIcon(status = message.status)
+                        Text(
+                            text = message.timestamp.toLocalDateTime(),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.outline
+                        )
+
+                        if (message.isFromMe) {
+                            Spacer(modifier = Modifier.width(4.dp))
+                            StatusIcon(status = message.status)
+                        }
                     }
                 }
             }
+        }
+
+        if (showReactionPicker) {
+            ReactionPickerRow(
+                onPick = { emoji ->
+                    onToggleReaction(emoji)
+                    showReactionPicker = false
+                }
+            )
+        }
+
+        if (message.reactions.isNotEmpty()) {
+            ReactionSummaryRow(
+                reactions = message.reactions,
+                onToggleReaction = onToggleReaction
+            )
+        }
+    }
+}
+
+@Composable
+private fun ReactionPickerRow(onPick: (String) -> Unit) {
+    Row(
+        modifier = Modifier.padding(top = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        QUICK_REACTIONS.forEach { emoji ->
+            AssistChip(
+                onClick = { onPick(emoji) },
+                label = { Text(emoji) },
+                colors = AssistChipDefaults.assistChipColors()
+            )
+        }
+    }
+}
+
+@Composable
+private fun ReactionSummaryRow(
+    reactions: Map<String, String>,
+    onToggleReaction: (String) -> Unit
+) {
+    val counts = reactions.values.groupingBy { it }.eachCount()
+    Row(
+        modifier = Modifier.padding(top = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        counts.forEach { (emoji, count) ->
+            AssistChip(
+                onClick = { onToggleReaction(emoji) },
+                label = { Text("$emoji $count") },
+                colors = AssistChipDefaults.assistChipColors()
+            )
         }
     }
 }

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/ChatScreen.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/ChatScreen.kt
@@ -184,8 +184,8 @@ fun IdentificationDialog(
 @Composable
 fun ChatMessageItem(
     message: ChatMessage,
+    modifier: Modifier = Modifier,
     onToggleReaction: (String) -> Unit = {},
-    modifier: Modifier = Modifier
 ) {
     var showReactionPicker by remember { mutableStateOf(false) }
     val alignment = if (message.isFromMe) Alignment.CenterEnd else Alignment.CenterStart

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/ChatViewModel.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/ChatViewModel.kt
@@ -11,6 +11,7 @@ import br.com.brunocarvalhs.chat.app.domain.usecase.ClearMessagesUseCase
 import br.com.brunocarvalhs.chat.app.domain.usecase.GetMessagesUseCase
 import br.com.brunocarvalhs.chat.app.domain.usecase.IdentifyUserUseCase
 import br.com.brunocarvalhs.chat.app.domain.usecase.SendMessageUseCase
+import br.com.brunocarvalhs.chat.app.domain.usecase.ToggleMessageReactionUseCase
 import br.com.brunocarvalhs.core.analytics.AnalyticsService
 import br.com.brunocarvalhs.core.analytics.commons.AnalyticsEvent
 import br.com.brunocarvalhs.core.domain.model.MessageModel
@@ -42,6 +43,7 @@ internal class ChatViewModel @Inject constructor(
     private val sendMessageUseCase: SendMessageUseCase,
     private val clearMessagesUseCase: ClearMessagesUseCase,
     private val identifyUserUseCase: IdentifyUserUseCase,
+    private val toggleMessageReactionUseCase: ToggleMessageReactionUseCase,
     private val deviceService: DeviceService,
     private val analyticsService: AnalyticsService
 ) : ViewModel() {
@@ -117,6 +119,28 @@ internal class ChatViewModel @Inject constructor(
             is ChatIntent.IdentifyUser -> identifyUser(intent.name)
             is ChatIntent.DismissIdentification -> _uiState.update { it.copy(showIdentificationModal = false) }
             is ChatIntent.ClearChat -> {}
+            is ChatIntent.ToggleReaction -> toggleReaction(intent.messageId, intent.emoji)
+        }
+    }
+
+    @AddTrace(name = "ChatViewModel.toggleReaction", enabled = true)
+    private fun toggleReaction(messageId: String, emoji: String) {
+        analyticsService.logEvent(
+            name = AnalyticsEvent.SUBMIT,
+            params = mapOf(
+                AnalyticsParam.ACTION to "toggle_message_reaction",
+                AnalyticsParam.PARAM to emoji
+            )
+        )
+        val message = _uiState.value.messages.find { it.id == messageId } ?: return
+        viewModelScope.launch {
+            toggleMessageReactionUseCase(
+                groupId = _uiState.value.groupModel.id,
+                messageId = messageId,
+                deviceId = deviceId,
+                currentReactions = message.reactions,
+                emoji = emoji
+            )
         }
     }
 
@@ -266,7 +290,8 @@ internal class ChatViewModel @Inject constructor(
             senderId = senderId,
             senderName = displayName,
             timestamp = timestamp,
-            status = status
+            status = status,
+            reactions = reactions
         )
     }
 }

--- a/features/chat/src/main/res/values-es/strings.xml
+++ b/features/chat/src/main/res/values-es/strings.xml
@@ -8,4 +8,5 @@
     <string name="identify_cancela">Cancelar</string>
     <string name="chat_input">Escribe un mensaje...</string>
     <string name="chat_button_send">Enviar</string>
+    <string name="react_to_message">Reaccionar al mensaje</string>
 </resources>

--- a/features/chat/src/main/res/values-ko/strings.xml
+++ b/features/chat/src/main/res/values-ko/strings.xml
@@ -8,4 +8,5 @@
     <string name="identify_cancela">취소</string>
     <string name="chat_input">메시지 입력...</string>
     <string name="chat_button_send">전송</string>
+    <string name="react_to_message">메시지에 반응하기</string>
 </resources>

--- a/features/chat/src/main/res/values-pt-rBR/strings.xml
+++ b/features/chat/src/main/res/values-pt-rBR/strings.xml
@@ -8,4 +8,5 @@
     <string name="identify_cancela">Cancelar</string>
     <string name="chat_input">Digite uma mensagem...</string>
     <string name="chat_button_send">Enviar</string>
+    <string name="react_to_message">Reagir à mensagem</string>
 </resources>

--- a/features/chat/src/main/res/values/strings.xml
+++ b/features/chat/src/main/res/values/strings.xml
@@ -8,4 +8,5 @@
     <string name="identify_cancela">Cancel</string>
     <string name="chat_input">Type a message...</string>
     <string name="chat_button_send">Send</string>
+    <string name="react_to_message">React to message</string>
 </resources>

--- a/features/chat/src/test/java/br/com/brunocarvalhs/chat/app/data/local/ReactionsConverterTest.kt
+++ b/features/chat/src/test/java/br/com/brunocarvalhs/chat/app/data/local/ReactionsConverterTest.kt
@@ -1,0 +1,38 @@
+package br.com.brunocarvalhs.chat.app.data.local
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class ReactionsConverterTest {
+
+    private lateinit var converter: ReactionsConverter
+
+    @Before
+    fun setup() {
+        converter = ReactionsConverter()
+    }
+
+    @Test
+    fun `fromReactions and toReactions should round trip`() {
+        // Given
+        val reactions = mapOf("device-1" to "👍", "device-2" to "❤️")
+
+        // When
+        val serialized = converter.fromReactions(reactions)
+        val deserialized = converter.toReactions(serialized)
+
+        // Then
+        assertEquals(reactions, deserialized)
+    }
+
+    @Test
+    fun `toReactions should return empty map for invalid input`() {
+        // When
+        val result = converter.toReactions("not-json")
+
+        // Then
+        assertTrue(result.isEmpty())
+    }
+}

--- a/features/chat/src/test/java/br/com/brunocarvalhs/chat/app/data/model/ChatMessageTest.kt
+++ b/features/chat/src/test/java/br/com/brunocarvalhs/chat/app/data/model/ChatMessageTest.kt
@@ -51,5 +51,18 @@ class ChatMessageTest {
         assertEquals("", message.text)
         assertEquals(MessageModel.MessageStatus.SENT, message.status)
         assertEquals(false, message.isFromMe)
+        assertEquals(emptyMap<String, String>(), message.reactions)
+    }
+
+    @Test
+    fun `constructor should set reactions`() {
+        // Given
+        val reactions = mapOf("device-1" to "👍")
+
+        // When
+        val message = ChatMessage(reactions = reactions)
+
+        // Then
+        assertEquals(reactions, message.reactions)
     }
 }

--- a/features/chat/src/test/java/br/com/brunocarvalhs/chat/app/data/repository/ChatRepositoryImplTest.kt
+++ b/features/chat/src/test/java/br/com/brunocarvalhs/chat/app/data/repository/ChatRepositoryImplTest.kt
@@ -62,4 +62,20 @@ class ChatRepositoryImplTest {
         assertTrue(result === expectedFlow)
         coVerify { chatService.getMessages(groupId) }
     }
+
+    @Test
+    fun `setReaction should call service and return success`() = runTest {
+        // Given
+        val groupId = "group1"
+        val messageId = "msg1"
+        val deviceId = "device1"
+        coEvery { chatService.setReaction(groupId, messageId, deviceId, "👍") } returns Result.success(Unit)
+
+        // When
+        val result = repository.setReaction(groupId, messageId, deviceId, "👍")
+
+        // Then
+        assertTrue(result.isSuccess)
+        coVerify { chatService.setReaction(groupId, messageId, deviceId, "👍") }
+    }
 }

--- a/features/chat/src/test/java/br/com/brunocarvalhs/chat/app/domain/usecase/ToggleMessageReactionUseCaseTest.kt
+++ b/features/chat/src/test/java/br/com/brunocarvalhs/chat/app/domain/usecase/ToggleMessageReactionUseCaseTest.kt
@@ -1,0 +1,62 @@
+package br.com.brunocarvalhs.chat.app.domain.usecase
+
+import br.com.brunocarvalhs.chat.app.domain.repository.ChatRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class ToggleMessageReactionUseCaseTest {
+
+    private val repository: ChatRepository = mockk()
+    private lateinit var useCase: ToggleMessageReactionUseCase
+
+    @Before
+    fun setup() {
+        useCase = ToggleMessageReactionUseCase(repository)
+    }
+
+    @Test
+    fun `invoke should set reaction when device has not reacted with this emoji`() = runTest {
+        // Given
+        coEvery { repository.setReaction("group1", "msg1", "device1", "👍") } returns Result.success(Unit)
+
+        // When
+        val result = useCase("group1", "msg1", "device1", emptyMap(), "👍")
+
+        // Then
+        assertTrue(result.isSuccess)
+        coVerify { repository.setReaction("group1", "msg1", "device1", "👍") }
+    }
+
+    @Test
+    fun `invoke should clear reaction when device already reacted with this emoji`() = runTest {
+        // Given
+        val currentReactions = mapOf("device1" to "👍")
+        coEvery { repository.setReaction("group1", "msg1", "device1", null) } returns Result.success(Unit)
+
+        // When
+        val result = useCase("group1", "msg1", "device1", currentReactions, "👍")
+
+        // Then
+        assertTrue(result.isSuccess)
+        coVerify { repository.setReaction("group1", "msg1", "device1", null) }
+    }
+
+    @Test
+    fun `invoke should replace reaction when device reacted with a different emoji`() = runTest {
+        // Given
+        val currentReactions = mapOf("device1" to "😂")
+        coEvery { repository.setReaction("group1", "msg1", "device1", "👍") } returns Result.success(Unit)
+
+        // When
+        val result = useCase("group1", "msg1", "device1", currentReactions, "👍")
+
+        // Then
+        assertTrue(result.isSuccess)
+        coVerify { repository.setReaction("group1", "msg1", "device1", "👍") }
+    }
+}


### PR DESCRIPTION
## Resumo
- `MessageModel` (core:domain) ganha `reactions: Map<String, String>` (deviceId → emoji).
- `FirebaseRealtimeManager` lê/escreve as reações num novo nó `r` dentro de cada mensagem no Realtime Database (não quebra mensagens já existentes, que simplesmente não têm o nó).
- Novo `ToggleMessageReactionUseCase`: se o dispositivo atual já reagiu com aquele emoji, remove; senão, define/substitui.
- UI (`ChatScreen`): ícone pequeno para abrir uma barra rápida com 5 emojis, e chips agregados (emoji + contagem) abaixo da mensagem — tocar num chip existente também alterna a reação do dispositivo atual.
- `ChatMessage` (entidade Room, hoje não conectada via Hilt/DI — usada só em teste local) ganha o mesmo campo + um `TypeConverter` (serialização JSON) para manter o schema consistente; versão do banco local incrementada (sem impacto em produção, já que essa base não é instanciada fora dos testes).
- Strings adicionadas nos 4 idiomas já suportados pelo módulo (en, pt-BR, es, ko).

## Escopo
`core:domain` (campo aditivo, com valor default — não quebra nenhum outro consumidor) + `features:chat`.

## Test plan
- [x] `./gradlew :features:chat:compileDebugKotlin` — sem erros
- [x] `./gradlew :features:chat:kspDebugKotlin` — Room aceitou o novo campo + TypeConverter sem erros de schema
- [x] `./gradlew :features:chat:testDebugUnitTest` — suíte completa passando (29 testes), incluindo os novos (`ToggleMessageReactionUseCaseTest`, `ReactionsConverterTest`, `ChatRepositoryImplTest#setReaction`, `ChatMessageTest`)
- [x] `./gradlew :core:domain:test` — suíte completa passando, incluindo o novo teste de `MessageModel.reactions`
- [ ] `detekt` não pôde ser validado neste ambiente (JDK 25 incompatível com o `jvmTarget` do detekt configurado no projeto — problema pré-existente do toolchain local)
- [ ] Teste manual em emulador/dispositivo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2XxUMSoZ4SVLZnBmydQhy