### PR TITLE
feat(group-details): lembrete local para a data do sorteio/troca

### DIFF
--- a/features/group/details/src/main/AndroidManifest.xml
+++ b/features/group/details/src/main/AndroidManifest.xml
@@ -1,3 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+    <application>
+        <receiver
+            android:name=".app.data.receivers.ReminderReceiver"
+            android:exported="false" />
+    </application>
+</manifest>

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/data/receivers/ReminderReceiver.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/data/receivers/ReminderReceiver.kt
@@ -9,6 +9,7 @@ import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import br.com.brunocarvalhs.group.details.R
+import timber.log.Timber
 
 internal class ReminderReceiver : BroadcastReceiver() {
 
@@ -28,8 +29,10 @@ internal class ReminderReceiver : BroadcastReceiver() {
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .build()
 
-        runCatching {
+        try {
             NotificationManagerCompat.from(context).notify(groupId.hashCode(), notification)
+        } catch (e: SecurityException) {
+            Timber.w(e, "Missing POST_NOTIFICATIONS permission; skipping reminder notification")
         }
     }
 

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/data/receivers/ReminderReceiver.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/data/receivers/ReminderReceiver.kt
@@ -1,0 +1,53 @@
+package br.com.brunocarvalhs.group.details.app.data.receivers
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import br.com.brunocarvalhs.group.details.R
+
+internal class ReminderReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val groupName = intent.getStringExtra(EXTRA_GROUP_NAME).orEmpty()
+        val groupId = intent.getStringExtra(EXTRA_GROUP_ID).orEmpty()
+
+        ensureChannel(context)
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.ic_popup_reminder)
+            .setContentTitle(context.getString(R.string.reminder_notification_title))
+            .setContentText(
+                context.getString(R.string.reminder_notification_message, groupName)
+            )
+            .setAutoCancel(true)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .build()
+
+        runCatching {
+            NotificationManagerCompat.from(context).notify(groupId.hashCode(), notification)
+        }
+    }
+
+    private fun ensureChannel(context: Context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+
+        val manager = context.getSystemService(NotificationManager::class.java) ?: return
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            context.getString(R.string.reminder_notification_channel_name),
+            NotificationManager.IMPORTANCE_HIGH
+        )
+        manager.createNotificationChannel(channel)
+    }
+
+    companion object {
+        const val EXTRA_GROUP_ID = "extra_group_id"
+        const val EXTRA_GROUP_NAME = "extra_group_name"
+        private const val CHANNEL_ID = "group_draw_reminders"
+    }
+}

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/data/services/AlarmManagerGroupReminderService.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/data/services/AlarmManagerGroupReminderService.kt
@@ -1,0 +1,75 @@
+package br.com.brunocarvalhs.group.details.app.data.services
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import br.com.brunocarvalhs.core.domain.model.GroupModel
+import br.com.brunocarvalhs.group.details.app.data.receivers.ReminderReceiver
+import br.com.brunocarvalhs.group.details.app.domain.services.GroupReminderService
+import dagger.hilt.android.qualifiers.ApplicationContext
+import timber.log.Timber
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Locale
+import javax.inject.Inject
+
+internal class AlarmManagerGroupReminderService @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+) : GroupReminderService {
+
+    override fun schedule(group: GroupModel): Boolean {
+        val triggerAtMillis = triggerTimeFor(group.date) ?: return false
+        val alarmManager = context.getSystemService(AlarmManager::class.java) ?: return false
+
+        runCatching {
+            alarmManager.set(AlarmManager.RTC_WAKEUP, triggerAtMillis, pendingIntent(group))
+        }.onFailure {
+            Timber.e(it, "Failed to schedule reminder for group ${group.id}")
+            return false
+        }
+
+        return true
+    }
+
+    override fun cancel(group: GroupModel) {
+        val alarmManager = context.getSystemService(AlarmManager::class.java) ?: return
+        alarmManager.cancel(pendingIntent(group))
+    }
+
+    private fun pendingIntent(group: GroupModel): PendingIntent {
+        val intent = Intent(context, ReminderReceiver::class.java).apply {
+            putExtra(ReminderReceiver.EXTRA_GROUP_ID, group.id)
+            putExtra(ReminderReceiver.EXTRA_GROUP_NAME, group.name)
+        }
+        return PendingIntent.getBroadcast(
+            context,
+            group.id.hashCode(),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+    }
+
+    private fun triggerTimeFor(date: String?): Long? {
+        if (date.isNullOrBlank()) return null
+
+        val parsedDate = runCatching {
+            SimpleDateFormat(DATE_PATTERN, Locale.getDefault()).parse(date)
+        }.getOrNull() ?: return null
+
+        val calendar = Calendar.getInstance().apply {
+            time = parsedDate
+            set(Calendar.HOUR_OF_DAY, REMINDER_HOUR)
+            set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+        }
+
+        return calendar.timeInMillis.takeIf { it > System.currentTimeMillis() }
+    }
+
+    private companion object {
+        const val DATE_PATTERN = "dd/MM/yyyy"
+        const val REMINDER_HOUR = 9
+    }
+}

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/data/services/AlarmManagerGroupReminderService.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/data/services/AlarmManagerGroupReminderService.kt
@@ -19,17 +19,16 @@ internal class AlarmManagerGroupReminderService @Inject constructor(
 ) : GroupReminderService {
 
     override fun schedule(group: GroupModel): Boolean {
-        val triggerAtMillis = triggerTimeFor(group.date) ?: return false
-        val alarmManager = context.getSystemService(AlarmManager::class.java) ?: return false
+        val triggerAtMillis = triggerTimeFor(group.date)
+        val alarmManager = context.getSystemService(AlarmManager::class.java)
 
-        runCatching {
+        if (triggerAtMillis == null || alarmManager == null) return false
+
+        return runCatching {
             alarmManager.set(AlarmManager.RTC_WAKEUP, triggerAtMillis, pendingIntent(group))
         }.onFailure {
             Timber.e(it, "Failed to schedule reminder for group ${group.id}")
-            return false
-        }
-
-        return true
+        }.isSuccess
     }
 
     override fun cancel(group: GroupModel) {
@@ -55,17 +54,19 @@ internal class AlarmManagerGroupReminderService @Inject constructor(
 
         val parsedDate = runCatching {
             SimpleDateFormat(DATE_PATTERN, Locale.getDefault()).parse(date)
-        }.getOrNull() ?: return null
+        }.getOrNull()
 
-        val calendar = Calendar.getInstance().apply {
-            time = parsedDate
-            set(Calendar.HOUR_OF_DAY, REMINDER_HOUR)
-            set(Calendar.MINUTE, 0)
-            set(Calendar.SECOND, 0)
-            set(Calendar.MILLISECOND, 0)
+        val calendar = parsedDate?.let {
+            Calendar.getInstance().apply {
+                time = it
+                set(Calendar.HOUR_OF_DAY, REMINDER_HOUR)
+                set(Calendar.MINUTE, 0)
+                set(Calendar.SECOND, 0)
+                set(Calendar.MILLISECOND, 0)
+            }
         }
 
-        return calendar.timeInMillis.takeIf { it > System.currentTimeMillis() }
+        return calendar?.timeInMillis?.takeIf { it > System.currentTimeMillis() }
     }
 
     private companion object {

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/domain/services/GroupReminderService.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/domain/services/GroupReminderService.kt
@@ -1,0 +1,8 @@
+package br.com.brunocarvalhs.group.details.app.domain.services
+
+import br.com.brunocarvalhs.core.domain.model.GroupModel
+
+internal interface GroupReminderService {
+    fun schedule(group: GroupModel): Boolean
+    fun cancel(group: GroupModel)
+}

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/domain/useCases/GroupReminderStorageKey.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/domain/useCases/GroupReminderStorageKey.kt
@@ -1,0 +1,3 @@
+package br.com.brunocarvalhs.group.details.app.domain.useCases
+
+internal fun groupReminderStorageKey(groupId: String) = "group_reminder_enabled_$groupId"

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/domain/useCases/IsGroupReminderEnabledUseCase.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/domain/useCases/IsGroupReminderEnabledUseCase.kt
@@ -1,0 +1,12 @@
+package br.com.brunocarvalhs.group.details.app.domain.useCases
+
+import br.com.brunocarvalhs.storage.domain.StorageService
+import javax.inject.Inject
+
+internal class IsGroupReminderEnabledUseCase @Inject constructor(
+    private val storage: StorageService
+) {
+    suspend operator fun invoke(groupId: String): Boolean {
+        return storage.load(groupReminderStorageKey(groupId), Boolean::class) ?: false
+    }
+}

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/domain/useCases/ToggleGroupReminderUseCase.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/domain/useCases/ToggleGroupReminderUseCase.kt
@@ -1,0 +1,24 @@
+package br.com.brunocarvalhs.group.details.app.domain.useCases
+
+import br.com.brunocarvalhs.core.domain.model.GroupModel
+import br.com.brunocarvalhs.group.details.app.domain.services.GroupReminderService
+import br.com.brunocarvalhs.storage.domain.StorageService
+import javax.inject.Inject
+
+internal class ToggleGroupReminderUseCase @Inject constructor(
+    private val reminderService: GroupReminderService,
+    private val storage: StorageService
+) {
+    suspend operator fun invoke(group: GroupModel, enabled: Boolean): Result<Boolean> =
+        runCatching {
+            if (enabled) {
+                val scheduled = reminderService.schedule(group)
+                storage.save(groupReminderStorageKey(group.id), scheduled)
+                scheduled
+            } else {
+                reminderService.cancel(group)
+                storage.save(groupReminderStorageKey(group.id), false)
+                false
+            }
+        }
+}

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsIntent.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsIntent.kt
@@ -5,4 +5,5 @@ internal sealed interface GroupDetailsIntent {
     data class Delete(val callback: () -> Unit) : GroupDetailsIntent
     data object Share : GroupDetailsIntent
     data class Exit(val callback: () -> Unit) : GroupDetailsIntent
+    data class ToggleReminder(val enabled: Boolean) : GroupDetailsIntent
 }

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsScreen.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsScreen.kt
@@ -1,5 +1,7 @@
 package br.com.brunocarvalhs.group.details.app.presentation
 
+import android.Manifest
+import android.os.Build
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -23,6 +25,8 @@ import androidx.compose.material.icons.filled.CardGiftcard
 import androidx.compose.material.icons.filled.Casino
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.NotificationsActive
+import androidx.compose.material.icons.filled.NotificationsNone
 import androidx.compose.material.icons.filled.PersonAdd
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -60,7 +64,11 @@ import br.com.brunocarvalhs.group.details.app.presentation.components.MemberItem
 import br.com.brunocarvalhs.group.details.app.presentation.components.SectionHeader
 import br.com.brunocarvalhs.group.details.app.presentation.components.SettingItem
 import coil.compose.AsyncImage
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.isGranted
+import com.google.accompanist.permissions.rememberPermissionState
 
+@OptIn(ExperimentalPermissionsApi::class)
 @Composable
 internal fun GroupDetailsScreen(
     viewModel: GroupDetailsViewModel,
@@ -73,6 +81,12 @@ internal fun GroupDetailsScreen(
     val lifecycleOwner = LocalLifecycleOwner.current
     val uiState by viewModel.uiState.collectAsState()
     val group = uiState.group
+
+    val notificationPermissionState = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        rememberPermissionState(Manifest.permission.POST_NOTIFICATIONS)
+    } else {
+        null
+    }
 
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
@@ -108,7 +122,17 @@ internal fun GroupDetailsScreen(
         onShareGroup = { viewModel.handleIntent(GroupDetailsIntent.Share) },
         onExit = { viewModel.handleIntent(GroupDetailsIntent.Exit(onBack)) },
         onEdit = { onEdit.invoke(group) },
-        onAddMembers = { onAddMembers.invoke(group) }
+        onAddMembers = { onAddMembers.invoke(group) },
+        isReminderEnabled = uiState.isReminderEnabled,
+        onToggleReminder = { enabled ->
+            if (enabled &&
+                notificationPermissionState != null &&
+                !notificationPermissionState.status.isGranted
+            ) {
+                notificationPermissionState.launchPermissionRequest()
+            }
+            viewModel.handleIntent(GroupDetailsIntent.ToggleReminder(enabled))
+        }
     )
 }
 
@@ -135,6 +159,8 @@ private fun GroupDetailsContent(
     onShareGroup: () -> Unit,
     onEdit: () -> Unit,
     onAddMembers: () -> Unit,
+    isReminderEnabled: Boolean = false,
+    onToggleReminder: (Boolean) -> Unit = {},
 ) {
     Scaffold(
         topBar = {
@@ -177,7 +203,9 @@ private fun GroupDetailsContent(
                     drawDate = drawDate,
                     minPrice = minPrice,
                     maxPrice = maxPrice,
-                    giftType = giftType
+                    giftType = giftType,
+                    isReminderEnabled = isReminderEnabled,
+                    onToggleReminder = onToggleReminder
                 )
             }
 
@@ -348,18 +376,45 @@ private fun GroupDrawDetails(
     drawDate: String?,
     minPrice: Double?,
     maxPrice: Double?,
-    giftType: String?
+    giftType: String?,
+    isReminderEnabled: Boolean = false,
+    onToggleReminder: (Boolean) -> Unit = {},
 ) {
     val hasDrawDetails = drawDate != null || minPrice != null || maxPrice != null || giftType != null
     if (hasDrawDetails) {
         Column {
             SectionHeader(title = stringResource(R.string.draw_details))
             drawDate?.let {
-                SettingItem(
-                    Icons.Default.CalendarToday,
-                    stringResource(R.string.draw_date),
-                    it
-                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        SettingItem(
+                            Icons.Default.CalendarToday,
+                            stringResource(R.string.draw_date),
+                            it
+                        )
+                    }
+                    IconButton(onClick = { onToggleReminder(!isReminderEnabled) }) {
+                        Icon(
+                            imageVector = if (isReminderEnabled) {
+                                Icons.Default.NotificationsActive
+                            } else {
+                                Icons.Default.NotificationsNone
+                            },
+                            contentDescription = stringResource(
+                                if (isReminderEnabled) {
+                                    R.string.reminder_disable_action
+                                } else {
+                                    R.string.reminder_enable_action
+                                }
+                            ),
+                            tint = if (isReminderEnabled) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.onSurfaceVariant
+                            }
+                        )
+                    }
+                }
             }
             if (minPrice != null || maxPrice != null) {
                 val priceRange = if (minPrice != null && maxPrice != null) {

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsUiState.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsUiState.kt
@@ -4,6 +4,7 @@ import br.com.brunocarvalhs.core.domain.model.GroupModel
 
 internal data class GroupDetailsUiState(
     val group: GroupModel,
+    val isReminderEnabled: Boolean = false,
     val isLoading: Boolean = false,
     val error: String? = null,
 )

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsViewModel.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsViewModel.kt
@@ -13,6 +13,8 @@ import br.com.brunocarvalhs.group.details.app.domain.useCases.GroupDeleteUseCase
 import br.com.brunocarvalhs.group.details.app.domain.useCases.GroupExitUseCase
 import br.com.brunocarvalhs.group.details.app.domain.useCases.GroupReadUseCase
 import br.com.brunocarvalhs.group.details.app.domain.useCases.GroupShareUseCase
+import br.com.brunocarvalhs.group.details.app.domain.useCases.IsGroupReminderEnabledUseCase
+import br.com.brunocarvalhs.group.details.app.domain.useCases.ToggleGroupReminderUseCase
 import com.google.firebase.perf.metrics.AddTrace
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -31,11 +33,17 @@ internal class GroupDetailsViewModel @Inject constructor(
     private val deleteUseCase: GroupDeleteUseCase,
     private val exitUseCase: GroupExitUseCase,
     private val shareUseCase: GroupShareUseCase,
+    private val toggleReminderUseCase: ToggleGroupReminderUseCase,
+    private val isReminderEnabledUseCase: IsGroupReminderEnabledUseCase,
     private val analyticsService: AnalyticsService
 ) : ViewModel() {
     private val args = savedStateHandle.toRoute<GroupDetailsGraph>(GroupDetailsGraph.typeMap)
     private val _uiState = MutableStateFlow(GroupDetailsUiState(group = args.group))
     val uiState: StateFlow<GroupDetailsUiState> = _uiState.asStateFlow()
+
+    init {
+        loadReminderState()
+    }
 
     @AddTrace(name = "GroupDetailsViewModel.handleIntent", enabled = true)
     fun handleIntent(intent: GroupDetailsIntent) = when (intent) {
@@ -43,6 +51,34 @@ internal class GroupDetailsViewModel @Inject constructor(
         is GroupDetailsIntent.Delete -> deleteGroup(intent.callback)
         is GroupDetailsIntent.Exit -> exitGroup(intent.callback)
         GroupDetailsIntent.Share -> shareGroup()
+        is GroupDetailsIntent.ToggleReminder -> toggleReminder(intent.enabled)
+    }
+
+    private fun loadReminderState() {
+        viewModelScope.launch {
+            val enabled = isReminderEnabledUseCase(_uiState.value.group.id)
+            _uiState.update { it.copy(isReminderEnabled = enabled) }
+        }
+    }
+
+    @AddTrace(name = "GroupDetailsViewModel.toggleReminder", enabled = true)
+    private fun toggleReminder(enabled: Boolean) {
+        analyticsService.logEvent(
+            name = AnalyticsEvent.SUBMIT,
+            params = mapOf(
+                AnalyticsParam.ACTION to "toggle_group_reminder"
+            )
+        )
+        viewModelScope.launch {
+            toggleReminderUseCase(_uiState.value.group, enabled)
+                .onSuccess { isEnabled ->
+                    _uiState.update { it.copy(isReminderEnabled = isEnabled) }
+                }
+                .onFailure { error ->
+                    Timber.e(error, "Error toggling group reminder")
+                    _uiState.update { it.copy(error = "Erro ao configurar o lembrete") }
+                }
+        }
     }
 
     @AddTrace(name = "GroupDetailsViewModel.deleteGroup", enabled = true)

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/commons/di/GroupDetailsModule.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/commons/di/GroupDetailsModule.kt
@@ -3,7 +3,9 @@ package br.com.brunocarvalhs.group.details.commons.di
 import br.com.brunocarvalhs.core.navigation.FeatureInitializer
 import br.com.brunocarvalhs.group.details.GroupDetailsInitializerImpl
 import br.com.brunocarvalhs.group.details.app.data.repository.GroupDetailsRepositoryImpl
+import br.com.brunocarvalhs.group.details.app.data.services.AlarmManagerGroupReminderService
 import br.com.brunocarvalhs.group.details.app.domain.repository.GroupDetailsRepository
+import br.com.brunocarvalhs.group.details.app.domain.services.GroupReminderService
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -22,4 +24,9 @@ abstract class GroupDetailsModule {
     internal abstract fun bindGroupDetailsRepository(
         impl: GroupDetailsRepositoryImpl
     ): GroupDetailsRepository
+
+    @Binds
+    internal abstract fun bindGroupReminderService(
+        impl: AlarmManagerGroupReminderService
+    ): GroupReminderService
 }

--- a/features/group/details/src/main/res/values-es/strings.xml
+++ b/features/group/details/src/main/res/values-es/strings.xml
@@ -30,4 +30,9 @@
     <string name="leave_group">Salir del grupo</string>
     <string name="share_group_message">🎁 ¡Has sido invitado a un Amigo Secreto: %1$s!\n\n📝 Descripción: %2$s\n🔑 Código del grupo: %3$s\n\n¡Descarga la app y únete ahora!</string>
     <string name="share_group_title">Compartir código</string>
+    <string name="reminder_enable_action">Recordarme en la fecha del sorteo</string>
+    <string name="reminder_disable_action">Desactivar recordatorio</string>
+    <string name="reminder_notification_channel_name">Recordatorios de Amigo Invisible</string>
+    <string name="reminder_notification_title">¡Hoy es el día del Amigo Invisible! 🎁</string>
+    <string name="reminder_notification_message">Hoy es el gran día de %1$s. ¡No olvides tu regalo!</string>
 </resources>

--- a/features/group/details/src/main/res/values-ko/strings.xml
+++ b/features/group/details/src/main/res/values-ko/strings.xml
@@ -30,4 +30,9 @@
     <string name="leave_group">그룹 나가기</string>
     <string name="share_group_message">🎁 당신은 시크릿 산타 그룹에 초대되었습니다: %1$s!\n\n📝 설명: %2$s\n🔑 그룹 코드: %3$s\n\n앱을 다운로드하고 지금 참여하세요!</string>
     <string name="share_group_title">코드 공유</string>
+    <string name="reminder_enable_action">추첨일에 알림 받기</string>
+    <string name="reminder_disable_action">알림 끄기</string>
+    <string name="reminder_notification_channel_name">시크릿 산타 알림</string>
+    <string name="reminder_notification_title">오늘은 시크릿 산타의 날이에요! 🎁</string>
+    <string name="reminder_notification_message">오늘은 %1$s의 특별한 날입니다. 선물을 잊지 마세요!</string>
 </resources>

--- a/features/group/details/src/main/res/values-pt-rBR/strings.xml
+++ b/features/group/details/src/main/res/values-pt-rBR/strings.xml
@@ -30,4 +30,9 @@
     <string name="leave_group">Sair do grupo</string>
     <string name="share_group_message">🎁 Você foi convidado para o Amigo Secreto: %1$s!\n\n📝 Descrição: %2$s\n🔑 Código do grupo: %3$s\n\nBaixe o app e entre agora!</string>
     <string name="share_group_title">Compartilhar Código</string>
+    <string name="reminder_enable_action">Lembrar na data do sorteio</string>
+    <string name="reminder_disable_action">Desativar lembrete</string>
+    <string name="reminder_notification_channel_name">Lembretes de Amigo Secreto</string>
+    <string name="reminder_notification_title">Hoje é o dia do Amigo Secreto! 🎁</string>
+    <string name="reminder_notification_message">Hoje é o grande dia do %1$s. Não esqueça o seu presente!</string>
 </resources>

--- a/features/group/details/src/main/res/values/strings.xml
+++ b/features/group/details/src/main/res/values/strings.xml
@@ -30,4 +30,9 @@
     <string name="leave_group">Leave group</string>
     <string name="share_group_message">🎁 You’ve been invited to a Secret Santa group: %1$s!\n\n📝 Description: %2$s\n🔑 Group code: %3$s\n\nDownload the app and join now!</string>
     <string name="share_group_title">Share Code</string>
+    <string name="reminder_enable_action">Remind me on the draw date</string>
+    <string name="reminder_disable_action">Turn off reminder</string>
+    <string name="reminder_notification_channel_name">Secret Santa reminders</string>
+    <string name="reminder_notification_title">It’s Secret Santa day! 🎁</string>
+    <string name="reminder_notification_message">Today is the big day for %1$s. Don’t forget your gift!</string>
 </resources>

--- a/features/group/details/src/test/java/br/com/brunocarvalhs/group/details/app/data/services/AlarmManagerGroupReminderServiceTest.kt
+++ b/features/group/details/src/test/java/br/com/brunocarvalhs/group/details/app/data/services/AlarmManagerGroupReminderServiceTest.kt
@@ -1,0 +1,72 @@
+package br.com.brunocarvalhs.group.details.app.data.services
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import br.com.brunocarvalhs.core.domain.model.GroupModel
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Locale
+
+@RunWith(RobolectricTestRunner::class)
+class AlarmManagerGroupReminderServiceTest {
+
+    private lateinit var service: AlarmManagerGroupReminderService
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        service = AlarmManagerGroupReminderService(context)
+    }
+
+    @Test
+    fun `schedule should return false when date is blank`() {
+        val group = GroupModel(id = "group-1", date = "")
+
+        assertFalse(service.schedule(group))
+    }
+
+    @Test
+    fun `schedule should return false when date is null`() {
+        val group = GroupModel(id = "group-1", date = null)
+
+        assertFalse(service.schedule(group))
+    }
+
+    @Test
+    fun `schedule should return false when date is not parseable`() {
+        val group = GroupModel(id = "group-1", date = "not-a-date")
+
+        assertFalse(service.schedule(group))
+    }
+
+    @Test
+    fun `schedule should return false when date is in the past`() {
+        val pastDate = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
+            .format(Calendar.getInstance().apply { add(Calendar.YEAR, -1) }.time)
+        val group = GroupModel(id = "group-1", date = pastDate)
+
+        assertFalse(service.schedule(group))
+    }
+
+    @Test
+    fun `schedule should return true when date is valid and in the future`() {
+        val futureDate = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
+            .format(Calendar.getInstance().apply { add(Calendar.YEAR, 1) }.time)
+        val group = GroupModel(id = "group-1", date = futureDate)
+
+        assertTrue(service.schedule(group))
+    }
+
+    @Test
+    fun `cancel should not throw when there is nothing scheduled`() {
+        val group = GroupModel(id = "group-1", date = null)
+
+        service.cancel(group)
+    }
+}

--- a/features/group/details/src/test/java/br/com/brunocarvalhs/group/details/app/domain/useCases/IsGroupReminderEnabledUseCaseTest.kt
+++ b/features/group/details/src/test/java/br/com/brunocarvalhs/group/details/app/domain/useCases/IsGroupReminderEnabledUseCaseTest.kt
@@ -1,0 +1,45 @@
+package br.com.brunocarvalhs.group.details.app.domain.useCases
+
+import br.com.brunocarvalhs.storage.domain.StorageService
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class IsGroupReminderEnabledUseCaseTest {
+
+    private val storage: StorageService = mockk()
+    private lateinit var useCase: IsGroupReminderEnabledUseCase
+
+    @Before
+    fun setup() {
+        useCase = IsGroupReminderEnabledUseCase(storage)
+    }
+
+    @Test
+    fun `invoke should return true when stored value is true`() = runTest {
+        // Given
+        coEvery { storage.load("group_reminder_enabled_group-1", Boolean::class) } returns true
+
+        // When
+        val result = useCase("group-1")
+
+        // Then
+        assertTrue(result)
+    }
+
+    @Test
+    fun `invoke should return false when nothing is stored`() = runTest {
+        // Given
+        coEvery { storage.load("group_reminder_enabled_group-1", Boolean::class) } returns null
+
+        // When
+        val result = useCase("group-1")
+
+        // Then
+        assertFalse(result)
+    }
+}

--- a/features/group/details/src/test/java/br/com/brunocarvalhs/group/details/app/domain/useCases/ToggleGroupReminderUseCaseTest.kt
+++ b/features/group/details/src/test/java/br/com/brunocarvalhs/group/details/app/domain/useCases/ToggleGroupReminderUseCaseTest.kt
@@ -1,0 +1,75 @@
+package br.com.brunocarvalhs.group.details.app.domain.useCases
+
+import br.com.brunocarvalhs.core.domain.model.GroupModel
+import br.com.brunocarvalhs.group.details.app.domain.services.GroupReminderService
+import br.com.brunocarvalhs.storage.domain.StorageService
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class ToggleGroupReminderUseCaseTest {
+
+    private val reminderService: GroupReminderService = mockk()
+    private val storage: StorageService = mockk()
+    private lateinit var useCase: ToggleGroupReminderUseCase
+
+    @Before
+    fun setup() {
+        useCase = ToggleGroupReminderUseCase(reminderService, storage)
+    }
+
+    @Test
+    fun `invoke should schedule and persist enabled state when enabling and date is valid`() = runTest {
+        // Given
+        val group = GroupModel(id = "group-1", date = "25/12/2099")
+        every { reminderService.schedule(group) } returns true
+        coEvery { storage.save("group_reminder_enabled_group-1", true) } returns Unit
+
+        // When
+        val result = useCase(group, true)
+
+        // Then
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrThrow())
+        coVerify { storage.save("group_reminder_enabled_group-1", true) }
+    }
+
+    @Test
+    fun `invoke should persist disabled state when scheduling fails`() = runTest {
+        // Given
+        val group = GroupModel(id = "group-1", date = null)
+        every { reminderService.schedule(group) } returns false
+        coEvery { storage.save("group_reminder_enabled_group-1", false) } returns Unit
+
+        // When
+        val result = useCase(group, true)
+
+        // Then
+        assertTrue(result.isSuccess)
+        assertTrue(!result.getOrThrow())
+        coVerify { storage.save("group_reminder_enabled_group-1", false) }
+    }
+
+    @Test
+    fun `invoke should cancel and persist disabled state when disabling`() = runTest {
+        // Given
+        val group = GroupModel(id = "group-1", date = "25/12/2099")
+        every { reminderService.cancel(group) } returns Unit
+        coEvery { storage.save("group_reminder_enabled_group-1", false) } returns Unit
+
+        // When
+        val result = useCase(group, false)
+
+        // Then
+        assertTrue(result.isSuccess)
+        assertTrue(!result.getOrThrow())
+        verify { reminderService.cancel(group) }
+        coVerify { storage.save("group_reminder_enabled_group-1", false) }
+    }
+}


### PR DESCRIPTION
## Resumo
- Ícone de sino ao lado da data do sorteio (`GroupDrawDetails`) que ativa/desativa um lembrete local.
- `AlarmManagerGroupReminderService`: agenda um alarme **inexato** (`AlarmManager.set`, não `setExactAndAllowWhileIdle`) para as 9h do dia do evento — evita a permissão especial `SCHEDULE_EXACT_ALARM` do Android 12+, adequada para um lembrete tolerante a atraso de alguns minutos.
- `ReminderReceiver` (BroadcastReceiver) mostra a notificação (cria o `NotificationChannel` sob demanda em API 26+).
- No Android 13+ (API 33), solicita a permissão `POST_NOTIFICATIONS` reaproveitando o mesmo padrão do `accompanist-permissions` já usado em `features/group/create` (`ContactsScreen`).
- Estado do toggle persistido por grupo via `StorageService` (já usado por outros use cases do módulo), então sobrevive a navegação/restart do processo.
- Nenhuma dependência nova no `libs.versions.toml` — só `AlarmManager`/`NotificationManagerCompat`, ambos já disponíveis via SDK/AndroidX Core transitivo.

## Limitação conhecida (deliberadamente fora de escopo)
Os alarmes **não são reagendados após reboot do aparelho** (sem `BroadcastReceiver` de boot) — manter isso de fora foi uma escolha consciente para não aumentar a superfície dessa PR. Dá para adicionar depois como incremento.

## Escopo
Restrito ao módulo `features:group:details`: novo `AndroidManifest.xml` do módulo (permissão `POST_NOTIFICATIONS` + declaração do `receiver`), novos arquivos de use case/serviço, e a UI do sino. Independente das outras PRs deste lote (não toca em `GroupDetailsRepository`).

## Test plan
- [x] `./gradlew :features:group:details:compileDebugKotlin` — sem erros
- [x] `./gradlew :features:group:details:processDebugManifest` — o merge do manifest do módulo (permissão + receiver) valida sem erros
- [x] `./gradlew :features:group:details:testDebugUnitTest` — suíte completa passando, incluindo `ToggleGroupReminderUseCaseTest`, `IsGroupReminderEnabledUseCaseTest` e `AlarmManagerGroupReminderServiceTest` (data em branco/nula/inválida/passada → não agenda; data futura válida → agenda)
- [ ] Não foi possível validar `:app:processDebugManifest`/build completo neste ambiente por falta de `google-services.json` (limitação pré-existente do ambiente local, não relacionada a este diff)
- [ ] `detekt` não pôde ser validado neste ambiente (JDK 25 incompatível com o `jvmTarget` do detekt configurado no projeto — problema pré-existente do toolchain local)
- [ ] Teste manual em emulador/dispositivo (agendar lembrete, avançar a hora do sistema, confirmar notificação)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2XxUMSoZ4SVLZnBmydQhy