### PR TITLE
feat(group-details): compartilhar o convite do grupo como QR Code

### DIFF
--- a/features/group/details/build.gradle.kts
+++ b/features/group/details/build.gradle.kts
@@ -90,6 +90,7 @@ dependencies {
     implementation(libs.timber)
     implementation(libs.gson)
     implementation(libs.accompanist.permissions)
+    implementation(libs.zxing.core)
 
     // Testes
     testImplementation(libs.junit)

--- a/features/group/details/src/main/AndroidManifest.xml
+++ b/features/group/details/src/main/AndroidManifest.xml
@@ -1,3 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <application>
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.group.details.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/qr_file_paths" />
+        </provider>
+    </application>
+</manifest>

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/data/services/QrCodeGenerator.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/data/services/QrCodeGenerator.kt
@@ -1,0 +1,27 @@
+package br.com.brunocarvalhs.group.details.app.data.services
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.qrcode.QRCodeWriter
+import javax.inject.Inject
+
+internal class QrCodeGenerator @Inject constructor() {
+
+    fun generate(content: String, size: Int = DEFAULT_SIZE): Bitmap? = runCatching {
+        val bitMatrix = QRCodeWriter().encode(content, BarcodeFormat.QR_CODE, size, size)
+        val bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.RGB_565)
+
+        for (x in 0 until size) {
+            for (y in 0 until size) {
+                bitmap.setPixel(x, y, if (bitMatrix[x, y]) Color.BLACK else Color.WHITE)
+            }
+        }
+
+        bitmap
+    }.getOrNull()
+
+    private companion object {
+        const val DEFAULT_SIZE = 512
+    }
+}

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/domain/useCases/ShareGroupQrCodeUseCase.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/domain/useCases/ShareGroupQrCodeUseCase.kt
@@ -1,0 +1,52 @@
+package br.com.brunocarvalhs.group.details.app.domain.useCases
+
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import androidx.core.content.FileProvider
+import br.com.brunocarvalhs.core.domain.model.GroupModel
+import br.com.brunocarvalhs.group.details.app.data.services.QrCodeGenerator
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import java.io.FileOutputStream
+import javax.inject.Inject
+
+internal class ShareGroupQrCodeUseCase @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+    private val qrCodeGenerator: QrCodeGenerator,
+) {
+    operator fun invoke(group: GroupModel): Result<Unit> = runCatching {
+        val bitmap = qrCodeGenerator.generate(group.token) ?: error("Could not generate QR code")
+        val uri = writeToCache(bitmap, group.token)
+
+        val sendIntent = Intent(Intent.ACTION_SEND).apply {
+            type = "image/png"
+            putExtra(Intent.EXTRA_STREAM, uri)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+
+        val chooser = Intent.createChooser(sendIntent, null).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+
+        context.startActivity(chooser)
+    }
+
+    private fun writeToCache(bitmap: Bitmap, token: String): android.net.Uri {
+        val directory = File(context.cacheDir, "qr_codes").apply { mkdirs() }
+        val file = File(directory, "qr_$token.png")
+        FileOutputStream(file).use { output ->
+            bitmap.compress(Bitmap.CompressFormat.PNG, QUALITY, output)
+        }
+        return FileProvider.getUriForFile(
+            context,
+            "${context.packageName}.group.details.fileprovider",
+            file
+        )
+    }
+
+    private companion object {
+        const val QUALITY = 100
+    }
+}

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsIntent.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsIntent.kt
@@ -4,5 +4,6 @@ internal sealed interface GroupDetailsIntent {
     data object Refresh : GroupDetailsIntent
     data class Delete(val callback: () -> Unit) : GroupDetailsIntent
     data object Share : GroupDetailsIntent
+    data object ShareQr : GroupDetailsIntent
     data class Exit(val callback: () -> Unit) : GroupDetailsIntent
 }

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsScreen.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.filled.Casino
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.PersonAdd
+import androidx.compose.material.icons.filled.QrCode
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -106,6 +107,7 @@ internal fun GroupDetailsScreen(
         onChat = { onChat.invoke(group) },
         onDelete = { viewModel.handleIntent(GroupDetailsIntent.Delete(onBack)) },
         onShareGroup = { viewModel.handleIntent(GroupDetailsIntent.Share) },
+        onShareQrCode = { viewModel.handleIntent(GroupDetailsIntent.ShareQr) },
         onExit = { viewModel.handleIntent(GroupDetailsIntent.Exit(onBack)) },
         onEdit = { onEdit.invoke(group) },
         onAddMembers = { onAddMembers.invoke(group) }
@@ -133,6 +135,7 @@ private fun GroupDetailsContent(
     onDelete: () -> Unit,
     onExit: () -> Unit,
     onShareGroup: () -> Unit,
+    onShareQrCode: () -> Unit,
     onEdit: () -> Unit,
     onAddMembers: () -> Unit,
 ) {
@@ -159,6 +162,7 @@ private fun GroupDetailsContent(
                 GroupDetailsActions(
                     isDrawn = isDrawn,
                     onShareGroup = onShareGroup,
+                    onShareQrCode = onShareQrCode,
                     onChat = onChat,
                     onDraw = onDraw
                 )
@@ -268,6 +272,7 @@ private fun GroupDetailsHeader(
 private fun GroupDetailsActions(
     isDrawn: Boolean,
     onShareGroup: () -> Unit,
+    onShareQrCode: () -> Unit,
     onChat: () -> Unit,
     onDraw: () -> Unit
 ) {
@@ -281,6 +286,10 @@ private fun GroupDetailsActions(
             ActionIconCard(
                 Icons.Default.Share,
                 stringResource(R.string.invite), onShareGroup
+            )
+            ActionIconCard(
+                Icons.Default.QrCode,
+                stringResource(R.string.qr_code), onShareQrCode
             )
             ActionIconCard(
                 Icons.AutoMirrored.Filled.Chat,
@@ -445,6 +454,7 @@ private fun GroupDetailsPreview() {
         onDelete = {},
         onExit = {},
         onShareGroup = {},
+        onShareQrCode = {},
         onEdit = {},
         onAddMembers = {}
     )

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsViewModel.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsViewModel.kt
@@ -13,6 +13,7 @@ import br.com.brunocarvalhs.group.details.app.domain.useCases.GroupDeleteUseCase
 import br.com.brunocarvalhs.group.details.app.domain.useCases.GroupExitUseCase
 import br.com.brunocarvalhs.group.details.app.domain.useCases.GroupReadUseCase
 import br.com.brunocarvalhs.group.details.app.domain.useCases.GroupShareUseCase
+import br.com.brunocarvalhs.group.details.app.domain.useCases.ShareGroupQrCodeUseCase
 import com.google.firebase.perf.metrics.AddTrace
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -31,6 +32,7 @@ internal class GroupDetailsViewModel @Inject constructor(
     private val deleteUseCase: GroupDeleteUseCase,
     private val exitUseCase: GroupExitUseCase,
     private val shareUseCase: GroupShareUseCase,
+    private val shareQrCodeUseCase: ShareGroupQrCodeUseCase,
     private val analyticsService: AnalyticsService
 ) : ViewModel() {
     private val args = savedStateHandle.toRoute<GroupDetailsGraph>(GroupDetailsGraph.typeMap)
@@ -43,6 +45,7 @@ internal class GroupDetailsViewModel @Inject constructor(
         is GroupDetailsIntent.Delete -> deleteGroup(intent.callback)
         is GroupDetailsIntent.Exit -> exitGroup(intent.callback)
         GroupDetailsIntent.Share -> shareGroup()
+        GroupDetailsIntent.ShareQr -> shareQrCode()
     }
 
     @AddTrace(name = "GroupDetailsViewModel.deleteGroup", enabled = true)
@@ -99,6 +102,23 @@ internal class GroupDetailsViewModel @Inject constructor(
         )
         viewModelScope.launch {
             shareUseCase(group = _uiState.value.group)
+        }
+    }
+
+    @AddTrace(name = "GroupDetailsViewModel.shareQrCode", enabled = true)
+    private fun shareQrCode() {
+        analyticsService.logEvent(
+            name = AnalyticsEvent.SUBMIT,
+            params = mapOf(
+                AnalyticsParam.ACTION to "share_group_qr_code"
+            )
+        )
+        viewModelScope.launch {
+            shareQrCodeUseCase(_uiState.value.group)
+                .onFailure { error ->
+                    Timber.e(error, "Error sharing group QR code")
+                    _uiState.update { it.copy(error = "Erro ao gerar QR Code") }
+                }
         }
     }
 

--- a/features/group/details/src/main/res/values-es/strings.xml
+++ b/features/group/details/src/main/res/values-es/strings.xml
@@ -30,4 +30,5 @@
     <string name="leave_group">Salir del grupo</string>
     <string name="share_group_message">🎁 ¡Has sido invitado a un Amigo Secreto: %1$s!\n\n📝 Descripción: %2$s\n🔑 Código del grupo: %3$s\n\n¡Descarga la app y únete ahora!</string>
     <string name="share_group_title">Compartir código</string>
+    <string name="qr_code">Código QR</string>
 </resources>

--- a/features/group/details/src/main/res/values-ko/strings.xml
+++ b/features/group/details/src/main/res/values-ko/strings.xml
@@ -30,4 +30,5 @@
     <string name="leave_group">그룹 나가기</string>
     <string name="share_group_message">🎁 당신은 시크릿 산타 그룹에 초대되었습니다: %1$s!\n\n📝 설명: %2$s\n🔑 그룹 코드: %3$s\n\n앱을 다운로드하고 지금 참여하세요!</string>
     <string name="share_group_title">코드 공유</string>
+    <string name="qr_code">QR 코드</string>
 </resources>

--- a/features/group/details/src/main/res/values-pt-rBR/strings.xml
+++ b/features/group/details/src/main/res/values-pt-rBR/strings.xml
@@ -30,4 +30,5 @@
     <string name="leave_group">Sair do grupo</string>
     <string name="share_group_message">🎁 Você foi convidado para o Amigo Secreto: %1$s!\n\n📝 Descrição: %2$s\n🔑 Código do grupo: %3$s\n\nBaixe o app e entre agora!</string>
     <string name="share_group_title">Compartilhar Código</string>
+    <string name="qr_code">QR Code</string>
 </resources>

--- a/features/group/details/src/main/res/values/strings.xml
+++ b/features/group/details/src/main/res/values/strings.xml
@@ -30,4 +30,5 @@
     <string name="leave_group">Leave group</string>
     <string name="share_group_message">🎁 You’ve been invited to a Secret Santa group: %1$s!\n\n📝 Description: %2$s\n🔑 Group code: %3$s\n\nDownload the app and join now!</string>
     <string name="share_group_title">Share Code</string>
+    <string name="qr_code">QR Code</string>
 </resources>

--- a/features/group/details/src/main/res/xml/qr_file_paths.xml
+++ b/features/group/details/src/main/res/xml/qr_file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="qr_codes" path="qr_codes/" />
+</paths>

--- a/features/group/details/src/test/java/br/com/brunocarvalhs/group/details/app/data/services/QrCodeGeneratorTest.kt
+++ b/features/group/details/src/test/java/br/com/brunocarvalhs/group/details/app/data/services/QrCodeGeneratorTest.kt
@@ -1,0 +1,39 @@
+package br.com.brunocarvalhs.group.details.app.data.services
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class QrCodeGeneratorTest {
+
+    private lateinit var generator: QrCodeGenerator
+
+    @Before
+    fun setup() {
+        generator = QrCodeGenerator()
+    }
+
+    @Test
+    fun `generate should return a bitmap with the requested size`() {
+        // When
+        val bitmap = generator.generate("ABC12345", size = 128)
+
+        // Then
+        assertNotNull(bitmap)
+        assertEquals(128, bitmap?.width)
+        assertEquals(128, bitmap?.height)
+    }
+
+    @Test
+    fun `generate should return null for blank content`() {
+        // When
+        val bitmap = generator.generate("")
+
+        // Then
+        assertEquals(null, bitmap)
+    }
+}

--- a/features/group/details/src/test/java/br/com/brunocarvalhs/group/details/app/domain/useCases/ShareGroupQrCodeUseCaseTest.kt
+++ b/features/group/details/src/test/java/br/com/brunocarvalhs/group/details/app/domain/useCases/ShareGroupQrCodeUseCaseTest.kt
@@ -1,0 +1,31 @@
+package br.com.brunocarvalhs.group.details.app.domain.useCases
+
+import android.app.Application
+import br.com.brunocarvalhs.core.domain.model.GroupModel
+import br.com.brunocarvalhs.group.details.app.data.services.QrCodeGenerator
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ShareGroupQrCodeUseCaseTest {
+
+    @Test
+    fun `invoke should fail when qr generator returns null`() {
+        // Given
+        val context: Application = org.robolectric.RuntimeEnvironment.getApplication()
+        val failingGenerator: QrCodeGenerator = mockk()
+        every { failingGenerator.generate(any(), any()) } returns null
+        val useCase = ShareGroupQrCodeUseCase(context, failingGenerator)
+        val group = GroupModel(id = "1", token = "ABC12345")
+
+        // When
+        val result = useCase(group)
+
+        // Then
+        assertTrue(result.isFailure)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,6 +57,7 @@ material = "1.13.0"
 core = "1.18.0"
 coreKtxVersion = "1.7.0"
 window = "1.5.1"
+zxingCore = "3.5.3"
 
 [libraries]
 accompanist-systemuicontroller = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "accompanistSystemuicontroller" }
@@ -121,6 +122,7 @@ material = { group = "com.google.android.material", name = "material", version.r
 androidx-core = { group = "androidx.core", name = "core", version.ref = "core" }
 core-ktx = { group = "androidx.test", name = "core-ktx", version.ref = "coreKtxVersion" }
 androidx-window = { module = "androidx.window:window", version.ref = "window" }
+zxing-core = { module = "com.google.zxing:core", version.ref = "zxingCore" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Resumo
- Nova biblioteca `com.google.zxing:core` (só encoding local, sem câmera/scanner) — adicionada ao `libs.versions.toml`.
- `QrCodeGenerator`: gera um `Bitmap` do QR a partir do token do grupo.
- `ShareGroupQrCodeUseCase`: salva o PNG no cache do app e compartilha via `Intent.ACTION_SEND` (`image/png`), reaproveitando o mesmo padrão de `GroupShareUseCase`. Usa um `FileProvider` escopado só para esse caso de uso (novo `<provider>` no manifest do módulo + `qr_file_paths.xml`).
- Novo botão "QR Code" ao lado de "Convidar" nas ações do grupo.

## Escopo deliberadamente reduzido
Isso é **só geração/compartilhamento do QR**, não leitura. Quem escaneia com a câmera nativa do Android vê o token como texto e cola no campo de entrada manual já existente — não abri escopo para leitura de QR dentro do app (câmera + parsing de barcode), que exigiria CameraX + ML Kit, uma permissão nova e uma tela de scanner. Isso fica como follow-up se fizer sentido.

## Escopo técnico
Restrito ao módulo `features:group:details` + entrada nova em `gradle/libs.versions.toml`.

## Test plan
- [x] `./gradlew :features:group:details:compileDebugKotlin` — sem erros
- [x] `./gradlew :features:group:details:processDebugManifest` — merge do `<provider>` do FileProvider valida sem erros
- [x] `./gradlew :features:group:details:testDebugUnitTest` — suíte completa passando, incluindo `QrCodeGeneratorTest` (tamanho do bitmap, conteúdo vazio retorna null) e `ShareGroupQrCodeUseCaseTest#generator-null`
- [ ] Não incluí um teste de "sucesso" ponta a ponta do `ShareGroupQrCodeUseCase` porque esse módulo não tem `isIncludeAndroidResources = true` habilitado (só o `:app` tem) — sem isso o `FileProvider` não resolve o XML de paths sob Robolectric. Mesma limitação que documentei no PR do lembrete (#62); não é algo que este diff quebrou.
- [ ] `detekt` não pôde ser validado neste ambiente (JDK 25 incompatível com o `jvmTarget` configurado — pré-existente)
- [ ] Teste manual em emulador/dispositivo (gerar QR, escanear com outro aparelho, compartilhar a imagem)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2XxUMSoZ4SVLZnBmydQhy