### PR TITLE
feat(group-draw): confete ao concluir o sorteio

### DIFF
--- a/features/group/draw/src/main/java/br/com/brunocarvalhs/group/draw/app/presentation/DrawScreen.kt
+++ b/features/group/draw/src/main/java/br/com/brunocarvalhs/group/draw/app/presentation/DrawScreen.kt
@@ -12,14 +12,20 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import br.com.brunocarvalhs.core.domain.model.UserModel
 import br.com.brunocarvalhs.group.draw.app.presentation.components.AnimatedDraw
+import br.com.brunocarvalhs.group.draw.app.presentation.components.ConfettiOverlay
 import br.com.brunocarvalhs.group.draw.app.presentation.components.DrawResultsList
 import br.com.brunocarvalhs.group.draw.app.presentation.components.DrawTopBar
+import kotlinx.coroutines.delay
 
 @Composable
 internal fun DrawScreen(
@@ -47,6 +53,18 @@ private fun DrawContent(
     val isDrawn = uiState.isDrawn
     val members = uiState.members
     val results = uiState.results
+
+    var previousIsDrawn by remember { mutableStateOf(isDrawn) }
+    var showCelebration by remember { mutableStateOf(false) }
+
+    LaunchedEffect(isDrawn) {
+        if (isDrawn && !previousIsDrawn) {
+            showCelebration = true
+            delay(CELEBRATION_DURATION_MS)
+            showCelebration = false
+        }
+        previousIsDrawn = isDrawn
+    }
 
     Scaffold(
         topBar = {
@@ -80,9 +98,13 @@ private fun DrawContent(
                     onShare = onShare
                 )
             }
+
+            ConfettiOverlay(visible = showCelebration)
         }
     }
 }
+
+private const val CELEBRATION_DURATION_MS = 2200L
 
 @Preview(uiMode = UI_MODE_NIGHT_NO, showBackground = true)
 @Preview(uiMode = UI_MODE_NIGHT_YES, showBackground = true)

--- a/features/group/draw/src/main/java/br/com/brunocarvalhs/group/draw/app/presentation/components/ConfettiOverlay.kt
+++ b/features/group/draw/src/main/java/br/com/brunocarvalhs/group/draw/app/presentation/components/ConfettiOverlay.kt
@@ -1,0 +1,88 @@
+package br.com.brunocarvalhs.group.draw.app.presentation.components
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.rotate
+import androidx.compose.ui.unit.dp
+import kotlin.random.Random
+
+private val CONFETTI_COLORS = listOf(
+    Color(0xFFE53935),
+    Color(0xFFFDD835),
+    Color(0xFF43A047),
+    Color(0xFF1E88E5),
+    Color(0xFFFF9800),
+    Color(0xFF8E24AA),
+)
+
+private data class ConfettiPiece(
+    val startXFraction: Float,
+    val fallDelayFraction: Float,
+    val driftAmplitude: Float,
+    val rotationSpeed: Float,
+    val sizeDp: Float,
+    val color: Color,
+)
+
+@Composable
+internal fun ConfettiOverlay(
+    visible: Boolean,
+    modifier: Modifier = Modifier,
+    particleCount: Int = 60,
+) {
+    if (!visible) return
+
+    val pieces = remember {
+        List(particleCount) {
+            ConfettiPiece(
+                startXFraction = Random.nextFloat(),
+                fallDelayFraction = Random.nextFloat() * 0.3f,
+                driftAmplitude = Random.nextFloat() * 60f - 30f,
+                rotationSpeed = Random.nextFloat() * 720f - 360f,
+                sizeDp = Random.nextFloat() * 6f + 6f,
+                color = CONFETTI_COLORS.random(),
+            )
+        }
+    }
+
+    val progress by animateFloatAsState(
+        targetValue = 1f,
+        animationSpec = tween(durationMillis = 2200, easing = LinearEasing),
+        label = "confettiProgress"
+    )
+
+    Canvas(modifier = modifier.fillMaxSize()) {
+        val canvasHeight = size.height
+        val canvasWidth = size.width
+
+        pieces.forEach { piece ->
+            val localProgress =
+                ((progress - piece.fallDelayFraction) / (1f - piece.fallDelayFraction))
+                    .coerceIn(0f, 1f)
+            if (localProgress <= 0f) return@forEach
+
+            val y = canvasHeight * localProgress
+            val x = canvasWidth * piece.startXFraction +
+                piece.driftAmplitude * kotlin.math.sin(localProgress * Math.PI * 2).toFloat()
+            val alpha = (1f - localProgress).coerceIn(0f, 1f)
+            val pieceSizePx = piece.sizeDp.dp.toPx()
+
+            rotate(degrees = piece.rotationSpeed * localProgress, pivot = Offset(x, y)) {
+                drawRect(
+                    color = piece.color.copy(alpha = alpha),
+                    topLeft = Offset(x - pieceSizePx / 2, y - pieceSizePx / 2),
+                    size = androidx.compose.ui.geometry.Size(pieceSizePx, pieceSizePx * 2)
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Resumo
- Novo `ConfettiOverlay`: sistema de partículas (confete) desenhado com `Canvas` + `animateFloatAsState`, ~2.2s, sem asset externo.
- Disparado em `DrawScreen` só na transição real `isDrawn: false -> true` dentro do ciclo de vida da tela (usa um `remember` do valor anterior) — reabrir uma tela já sorteada não replay o confete.

## Sobre não usar Lottie
Eu tinha sugerido usar `lottie-compose` (já é dependência do módulo `features:group:draw`, mas **não está conectado a nenhum asset em lugar nenhum do código** — mais um caso do padrão "dependência declarada, nunca usada" que já vinha aparecendo neste projeto). Não tinha como sourcing/criar um arquivo `.json` de animação licenciado de forma responsável neste ambiente, então optei por uma implementação 100% Compose (Canvas + animação), que dá um resultado visual equivalente sem esse risco.

## Escopo
Restrito ao módulo `features:group:draw`. Nenhuma dependência nova.

## Test plan
- [x] `./gradlew :features:group:draw:compileDebugKotlin` — sem erros
- [x] `./gradlew :features:group:draw:testDebugUnitTest` — suíte existente passando (o módulo não tem testes de UI Compose para telas, então não há um padrão a seguir para testar o novo composable — consistente com a cobertura já existente)
- [ ] `detekt` não pôde ser validado neste ambiente (JDK 25 incompatível com o `jvmTarget` configurado — pré-existente)
- [ ] Teste manual em emulador/dispositivo (visual da animação, timing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2XxUMSoZ4SVLZnBmydQhy