### PR TITLE
feat(group-details): preview rico para links de produto na wishlist

### DIFF
--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/data/services/LinkMetadataFetcher.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/data/services/LinkMetadataFetcher.kt
@@ -1,0 +1,67 @@
+package br.com.brunocarvalhs.group.details.app.data.services
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.net.HttpURLConnection
+import java.net.URL
+import javax.inject.Inject
+
+internal data class LinkMetadata(
+    val title: String? = null,
+    val imageUrl: String? = null,
+)
+
+internal class LinkMetadataFetcher @Inject constructor() {
+
+    suspend fun fetch(url: String): LinkMetadata? = withContext(Dispatchers.IO) {
+        runCatching {
+            val connection = (URL(url).openConnection() as HttpURLConnection).apply {
+                connectTimeout = TIMEOUT_MS
+                readTimeout = TIMEOUT_MS
+                instanceFollowRedirects = true
+                setRequestProperty("User-Agent", USER_AGENT)
+            }
+
+            connection.inputStream.bufferedReader().use { reader ->
+                val buffer = CharArray(MAX_CHARS)
+                val read = reader.read(buffer, 0, MAX_CHARS)
+                val html = if (read > 0) String(buffer, 0, read) else ""
+                parseMetadata(html)
+            }
+        }.getOrNull()
+    }
+
+    internal fun parseMetadata(html: String): LinkMetadata {
+        val title = OG_TITLE_REGEX.find(html)?.groupValues?.get(1)
+            ?: TITLE_TAG_REGEX.find(html)?.groupValues?.get(1)
+        val image = OG_IMAGE_REGEX.find(html)?.groupValues?.get(1)
+
+        return LinkMetadata(
+            title = title?.let { decodeHtmlEntities(it).trim() }?.takeIf { it.isNotBlank() },
+            imageUrl = image?.let { decodeHtmlEntities(it).trim() }?.takeIf { it.isNotBlank() },
+        )
+    }
+
+    private fun decodeHtmlEntities(text: String): String = text
+        .replace("&amp;", "&")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+
+    private companion object {
+        const val TIMEOUT_MS = 4000
+        const val MAX_CHARS = 65_536
+        const val USER_AGENT = "Mozilla/5.0 (compatible; FriendsSecretsLinkPreview/1.0)"
+
+        val OG_TITLE_REGEX = Regex(
+            """<meta[^>]+property=["']og:title["'][^>]+content=["']([^"']*)["']""",
+            RegexOption.IGNORE_CASE
+        )
+        val OG_IMAGE_REGEX = Regex(
+            """<meta[^>]+property=["']og:image["'][^>]+content=["']([^"']*)["']""",
+            RegexOption.IGNORE_CASE
+        )
+        val TITLE_TAG_REGEX = Regex("""<title[^>]*>([^<]*)</title>""", RegexOption.IGNORE_CASE)
+    }
+}

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/data/services/UrlUtils.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/data/services/UrlUtils.kt
@@ -1,0 +1,7 @@
+package br.com.brunocarvalhs.group.details.app.data.services
+
+private val HTTP_URL_REGEX = Regex("""^https?://\S+\.\S+""", RegexOption.IGNORE_CASE)
+
+internal fun isLikelyUrl(text: String): Boolean {
+    return HTTP_URL_REGEX.matches(text.trim())
+}

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsScreen.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsScreen.kt
@@ -199,6 +199,7 @@ private fun GroupDetailsContent(
             items(members) { member ->
                 MemberItem(
                     participant = member.name,
+                    likes = member.likes,
                     isAdministrator = isOwner,
                 )
             }

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/components/ContactItem.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/components/ContactItem.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import br.com.brunocarvalhs.core.domain.model.GroupModel
 import br.com.brunocarvalhs.group.details.R
+import br.com.brunocarvalhs.group.details.app.data.services.isLikelyUrl
 import coil.compose.AsyncImage
 
 @Composable
@@ -168,7 +169,9 @@ internal fun ContactItem(
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         items(filteredLikes) { like ->
-                            if (like.isNotBlank()) {
+                            if (isLikelyUrl(like)) {
+                                LinkPreviewChip(url = like.trim())
+                            } else if (like.isNotBlank()) {
                                 AssistChip(onClick = {}, label = { Text(like) })
                             }
                         }

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/components/LinkPreviewChip.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/components/LinkPreviewChip.kt
@@ -1,0 +1,97 @@
+package br.com.brunocarvalhs.group.details.app.presentation.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Link
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import br.com.brunocarvalhs.group.details.app.data.services.LinkMetadata
+import br.com.brunocarvalhs.group.details.app.data.services.LinkMetadataFetcher
+import coil.compose.AsyncImage
+import java.net.URI
+
+@Composable
+internal fun LinkPreviewChip(url: String) {
+    val fetcher = remember { LinkMetadataFetcher() }
+    var metadata by remember(url) { mutableStateOf<LinkMetadata?>(null) }
+    var isLoading by remember(url) { mutableStateOf(true) }
+    val uriHandler = LocalUriHandler.current
+
+    LaunchedEffect(url) {
+        metadata = fetcher.fetch(url)
+        isLoading = false
+    }
+
+    val host = remember(url) { runCatching { URI(url).host }.getOrNull() ?: url }
+
+    Surface(
+        shape = RoundedCornerShape(12.dp),
+        tonalElevation = 1.dp,
+        modifier = Modifier
+            .widthIn(max = 220.dp)
+            .clickable { runCatching { uriHandler.openUri(url) } }
+    ) {
+        Row(modifier = Modifier.padding(8.dp)) {
+            val imageUrl = metadata?.imageUrl
+            if (!imageUrl.isNullOrBlank()) {
+                AsyncImage(
+                    model = imageUrl,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(48.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                )
+            } else {
+                Icon(
+                    imageVector = Icons.Filled.Link,
+                    contentDescription = null,
+                    modifier = Modifier.size(48.dp).padding(12.dp)
+                )
+            }
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            Column {
+                if (isLoading) {
+                    CircularProgressIndicator(modifier = Modifier.size(16.dp))
+                } else {
+                    Text(
+                        text = metadata?.title ?: host,
+                        style = MaterialTheme.typography.labelMedium,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Text(
+                        text = host,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+        }
+    }
+}

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/components/MemberItem.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/components/MemberItem.kt
@@ -24,6 +24,7 @@ internal fun MemberItem(
 
     ContactItem(
         name = participant,
+        likes = likes,
         action = { _, isLiked ->
 
             if (hasLikes) {

--- a/features/group/details/src/test/java/br/com/brunocarvalhs/group/details/app/data/services/LinkMetadataFetcherTest.kt
+++ b/features/group/details/src/test/java/br/com/brunocarvalhs/group/details/app/data/services/LinkMetadataFetcherTest.kt
@@ -1,0 +1,72 @@
+package br.com.brunocarvalhs.group.details.app.data.services
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class LinkMetadataFetcherTest {
+
+    private lateinit var fetcher: LinkMetadataFetcher
+
+    @Before
+    fun setup() {
+        fetcher = LinkMetadataFetcher()
+    }
+
+    @Test
+    fun `parseMetadata should extract og title and image`() {
+        // Given
+        val html = """
+            <html><head>
+            <meta property="og:title" content="Nice Board Game" />
+            <meta property="og:image" content="https://cdn.example.com/game.png" />
+            </head></html>
+        """.trimIndent()
+
+        // When
+        val metadata = fetcher.parseMetadata(html)
+
+        // Then
+        assertEquals("Nice Board Game", metadata.title)
+        assertEquals("https://cdn.example.com/game.png", metadata.imageUrl)
+    }
+
+    @Test
+    fun `parseMetadata should fall back to title tag when og title is missing`() {
+        // Given
+        val html = "<html><head><title>Fallback Title</title></head></html>"
+
+        // When
+        val metadata = fetcher.parseMetadata(html)
+
+        // Then
+        assertEquals("Fallback Title", metadata.title)
+        assertNull(metadata.imageUrl)
+    }
+
+    @Test
+    fun `parseMetadata should decode common html entities`() {
+        // Given
+        val html = """<meta property="og:title" content="Rock &amp; Roll" />"""
+
+        // When
+        val metadata = fetcher.parseMetadata(html)
+
+        // Then
+        assertEquals("Rock & Roll", metadata.title)
+    }
+
+    @Test
+    fun `parseMetadata should return nulls for html without metadata`() {
+        // Given
+        val html = "<html><body>Nothing here</body></html>"
+
+        // When
+        val metadata = fetcher.parseMetadata(html)
+
+        // Then
+        assertNull(metadata.title)
+        assertNull(metadata.imageUrl)
+    }
+}

--- a/features/group/details/src/test/java/br/com/brunocarvalhs/group/details/app/data/services/UrlUtilsTest.kt
+++ b/features/group/details/src/test/java/br/com/brunocarvalhs/group/details/app/data/services/UrlUtilsTest.kt
@@ -1,0 +1,28 @@
+package br.com.brunocarvalhs.group.details.app.data.services
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UrlUtilsTest {
+
+    @Test
+    fun `isLikelyUrl should return true for http and https urls`() {
+        assertTrue(isLikelyUrl("https://www.example.com/product/123"))
+        assertTrue(isLikelyUrl("http://example.com"))
+        assertTrue(isLikelyUrl("  https://example.com  "))
+    }
+
+    @Test
+    fun `isLikelyUrl should return false for plain text`() {
+        assertFalse(isLikelyUrl("Books"))
+        assertFalse(isLikelyUrl("Games and coffee"))
+        assertFalse(isLikelyUrl(""))
+    }
+
+    @Test
+    fun `isLikelyUrl should return false for non http schemes`() {
+        assertFalse(isLikelyUrl("ftp://example.com/file"))
+        assertFalse(isLikelyUrl("javascript:alert(1)"))
+    }
+}


### PR DESCRIPTION
## Resumo
- `LinkMetadataFetcher`: busca o HTML da URL (`HttpURLConnection`, timeout de 4s, limite de 64KB lidos) e extrai `og:title`/`og:image` (com fallback pra tag `<title>`) via regex — sem adicionar um parser de HTML ou cliente HTTP novo ao projeto, já que só preciso de duas meta tags.
- `LinkPreviewChip`: card com miniatura + título no lugar do chip de texto puro, quando o item da wishlist é uma URL http(s) (`isLikelyUrl`). Toque abre o link no navegador padrão.
- Conectado em `ContactItem` (usado por `MemberItem`), com fallback para o host da URL se a busca falhar ou não retornar título.

## Bug pré-existente corrigido
`MemberItem` calculava `hasLikes` a partir do parâmetro `likes`, mas **nunca repassava essa lista pro `ContactItem`** — então a seção de "likes" nunca renderizava nada, independente do que fosse passado. Sem corrigir isso, essa feature não teria onde aparecer. Também adicionei `likes = member.likes` na chamada de `MemberItem` em `GroupDetailsScreen` (também não estava conectado na `develop`).

## Escopo
Restrito ao módulo `features:group:details`. Nenhuma dependência nova.

## Test plan
- [x] `./gradlew :features:group:details:compileDebugKotlin` — sem erros
- [x] `./gradlew :features:group:details:testDebugUnitTest` — suíte completa passando, incluindo `UrlUtilsTest` e `LinkMetadataFetcherTest` (parsing de `og:title`/`og:image`, fallback pra `<title>`, decodificação de entidades HTML, HTML sem metadados)
- [ ] Não testei a chamada de rede real (`fetch()`) — segue o mesmo padrão do resto do projeto de não testar diretamente classes que fazem I/O de rede (ex: `FirebaseRealtimeManager` também não tem teste); só a lógica de parsing, que é a parte de maior risco, está coberta
- [ ] `detekt` não pôde ser validado neste ambiente (JDK 25 incompatível com o `jvmTarget` configurado — pré-existente)
- [ ] Teste manual em emulador/dispositivo (colar um link real de produto e ver o preview carregar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2XxUMSoZ4SVLZnBmydQhy