### PR TITLE
perf(r8): remove redundant keeps so R8 actually optimizes the release build

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,16 +1,7 @@
-# Manter classes e métodos do Android
--keep class android.** { *; }
--keep class androidx.** { *; }
-
-# Manter classes do ciclo de vida e ViewModel
--keep class androidx.lifecycle.** { *; }
--keepclassmembers class androidx.lifecycle.** { *; }
--keep class androidx.activity.** { *; }
-
-# Manter classes do Jetpack Compose
--keep class androidx.compose.** { *; }
--keep class androidx.ui.** { *; }
--keep class androidx.material3.** { *; }
+# AndroidX / Compose / platform classes are NOT kept here: every AndroidX and
+# Compose artifact ships its own consumer-rules.pro that AGP merges
+# automatically, so a blanket app-level -keep only bloats the APK and blocks
+# R8 from shrinking/obfuscating the largest chunk of the app's bytecode.
 
 # Manter classes do Firebase
 -keep class com.google.firebase.** { *; }
@@ -18,8 +9,7 @@
 
 # Manter classes do Gson
 -keep class com.google.gson.** { *; }
--keepattributes Signature
--keepattributes *Annotation*
+-keepattributes Signature,*Annotation*,InnerClasses
 
 # Manter classes do Timber
 -keep class com.jakewharton.timber.** { *; }
@@ -27,27 +17,14 @@
 # Manter classes do Lottie
 -keep class com.airbnb.lottie.** { *; }
 
-# Manter classes do Generative AI (caso tenha anotações específicas)
--keep class com.generativeai.** { *; }
-
-# Manter classes de navegação
--keep class androidx.navigation.** { *; }
-
-# Manter classes de animação
--keep class androidx.compose.animation.** { *; }
-
 # Regras de testes
 -keep class org.junit.** { *; }
 -keep class androidx.test.** { *; }
-
-# Manter anotações de Retrofit
--keepattributes *Annotation*
 
 # Manter anotações de Gson
 -keep @com.google.gson.annotations.SerializedName class * { *; }
 
 # Kotlin Serialization
--keepattributes *Annotation*, InnerClasses
 -keep,allowobfuscation,allowshrinking class * {
     @kotlinx.serialization.Serializable *;
 }
@@ -83,10 +60,14 @@
     <init>(...);
 }
 
-# Segurança adicional: Ofuscação agressiva para o resto do app
+# Segurança adicional: ofuscação agressiva para o resto do app
 #-repackageclasses '' # Commeting this out as it often causes issues with DI and navigation
 -allowaccessmodification
--overloadaggressively
+
+# Mantém o número da linha para stack traces legíveis via mapping.txt, mas
+# troca o nome do arquivo-fonte real por "SourceFile" no APK final.
+-keepattributes SourceFile,LineNumberTable
+-renamesourcefileattribute SourceFile
 
 # Para facilitar o diagnóstico
 -printmapping mapping.txt

--- a/core/ui/consumer-rules.pro
+++ b/core/ui/consumer-rules.pro
@@ -2,6 +2,6 @@
 -keep class br.com.brunocarvalhs.core.ui.** { *; }
 -dontwarn br.com.brunocarvalhs.core.ui.**
 
-# Keep Compose internal classes that might be needed
--keep class androidx.compose.ui.** { *; }
--keep class androidx.compose.material3.** { *; }
+# androidx.compose.ui / androidx.compose.material3 are not kept here: those
+# artifacts ship their own consumer-rules.pro, and an app/module-level
+# blanket -keep only blocks R8 from shrinking and obfuscating them.


### PR DESCRIPTION
## Summary
- `isMinifyEnabled = true` was already set for `release`, but `app/proguard-rules.pro` had blanket `-keep` rules for `android.**`, `androidx.**`, and individually for `androidx.lifecycle`, `androidx.activity`, `androidx.compose.**`, `androidx.ui.**`, `androidx.material3`, `androidx.navigation`, `androidx.compose.animation` — these exempted almost all AndroidX/Compose bytecode (the largest chunk of a Compose app) from shrinking and obfuscation, making R8 mostly cosmetic.
- Those AndroidX/Compose/Firebase artifacts already ship their own `consumer-rules.pro` inside their AARs, which AGP merges automatically — the app-level overrides were pure redundancy, not a safety net.
- Same redundant pattern removed from `core/ui/consumer-rules.pro` (`androidx.compose.ui.**`, `androidx.compose.material3.**`).
- Dropped a dead rule referencing a `com.generativeai` package that isn't a project dependency, and `-overloadaggressively` (a legacy ProGuard flag R8 doesn't act on).
- Added `-keepattributes SourceFile,LineNumberTable` + `-renamesourcefileattribute SourceFile`: crash stack traces stay symbolicated via the uploaded `mapping.txt` (Crashlytics), but the real source file name is stripped from the shipped APK — standard R8 hardening for both perf (smaller mapping) and security (less info leakage).

## Scope / what's intentionally NOT in this PR
Every feature/core module's own `consumer-rules.pro` still has a blanket `-keep class br.com.brunocarvalhs.<module>.** { *; }`, so the app's own business-logic code is still fully exempt from shrinking/obfuscation. Untangling that is higher blast-radius (needs a per-module reflection audit — Hilt codegen, Room, custom multibinding, etc. — plus full manual QA on an installed obfuscated release build) and wasn't attempted here since this environment has no adb/emulator to verify runtime behavior after obfuscation. Flagging as a natural follow-up.

## Test plan
- [x] `./gradlew :app:assembleRelease` locally — `:app:minifyReleaseWithR8` completes successfully; build only fails afterward at `packageRelease` due to missing local signing secrets (`KEYSTORE_PASSWORD` etc. are CI-only secrets, expected in a local run).
- [ ] Install the CI-built, signed release APK on a device and run the full manual QA pass (nav flows, Compose animations, biometric, chat/Room, Firestore) to confirm nothing relied on the removed AndroidX/Compose keeps.
- [ ] Compare APK size before/after in the build artifacts.