### PR TITLE
fix(group-details): scrollable action cards + QR scan to join a group

### DIFF
--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsScreen.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsScreen.kt
@@ -3,9 +3,11 @@ package br.com.brunocarvalhs.group.details.app.presentation
 import android.Manifest
 import android.os.Build
 import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -379,8 +381,9 @@ private fun GroupDetailsActions(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
+                .horizontalScroll(rememberScrollState())
                 .padding(horizontal = 16.dp),
-            horizontalArrangement = Arrangement.SpaceEvenly
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             ActionIconCard(
                 Icons.Default.Share,

--- a/features/group/list/build.gradle.kts
+++ b/features/group/list/build.gradle.kts
@@ -93,6 +93,7 @@ dependencies {
     implementation(libs.timber)
     implementation(libs.gson)
     implementation(libs.accompanist.permissions)
+    implementation(libs.zxing.android.embedded)
 
     // Testes
     testImplementation(libs.junit)

--- a/features/group/list/src/main/java/br/com/brunocarvalhs/group/list/app/presentation/components/GroupToEnterBottomSheet.kt
+++ b/features/group/list/src/main/java/br/com/brunocarvalhs/group/list/app/presentation/components/GroupToEnterBottomSheet.kt
@@ -1,19 +1,27 @@
 package br.com.brunocarvalhs.group.list.app.presentation.components
 
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.QrCodeScanner
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -24,6 +32,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -38,6 +47,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import br.com.brunocarvalhs.group.list.R
+import com.journeyapps.barcodescanner.ScanContract
+import com.journeyapps.barcodescanner.ScanOptions
 import kotlinx.coroutines.launch
 
 private const val TOKEN_MAX_LENGTH = 8
@@ -61,6 +72,26 @@ fun GroupToEnterBottomSheet(
 
     var token by remember { mutableStateOf("") }
     val focusRequester = remember { FocusRequester() }
+
+    fun submit(value: String) {
+        scope.launch {
+            sheetState.hide()
+            onToEnter(value)
+            token = ""
+        }.invokeOnCompletion {
+            if (!sheetState.isVisible) {
+                onDismiss()
+            }
+        }
+    }
+
+    val scanPrompt = stringResource(R.string.group_to_enter_scan_prompt)
+    val scanLauncher = rememberLauncherForActivityResult(ScanContract()) { result ->
+        val scanned = result.contents?.trim()?.uppercase().orEmpty()
+        if (scanned.isNotBlank()) {
+            submit(scanned)
+        }
+    }
 
     LaunchedEffect(sheetState.isVisible) {
         if (sheetState.isVisible) {
@@ -93,16 +124,15 @@ fun GroupToEnterBottomSheet(
                 }
             },
             focusRequester = focusRequester,
-            onActionClick = {
-                scope.launch {
-                    sheetState.hide()
-                    onToEnter(token)
-                    token = ""
-                }.invokeOnCompletion {
-                    if (!sheetState.isVisible) {
-                        onDismiss()
-                    }
-                }
+            onActionClick = { submit(token) },
+            onScanQrCode = {
+                scanLauncher.launch(
+                    ScanOptions()
+                        .setDesiredBarcodeFormats(ScanOptions.QR_CODE)
+                        .setPrompt(scanPrompt)
+                        .setBeepEnabled(false)
+                        .setOrientationLocked(true)
+                )
             }
         )
     }
@@ -113,7 +143,8 @@ private fun GroupToEnterContent(
     token: String,
     onTokenChange: (String) -> Unit,
     focusRequester: FocusRequester,
-    onActionClick: () -> Unit
+    onActionClick: () -> Unit,
+    onScanQrCode: () -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -153,6 +184,29 @@ private fun GroupToEnterContent(
             enabled = token.length == TOKEN_MAX_LENGTH
         ) {
             Text(stringResource(R.string.group_to_enter_button_text))
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            HorizontalDivider(modifier = Modifier.weight(1f))
+            Text(
+                text = stringResource(R.string.group_to_enter_divider),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            HorizontalDivider(modifier = Modifier.weight(1f))
+        }
+
+        OutlinedButton(
+            onClick = onScanQrCode,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Icon(Icons.Default.QrCodeScanner, contentDescription = null)
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(stringResource(R.string.group_to_enter_scan_qr_code))
         }
     }
 }

--- a/features/group/list/src/main/res/values-de/strings.xml
+++ b/features/group/list/src/main/res/values-de/strings.xml
@@ -31,6 +31,9 @@
     <string name="group_to_enter_button_text">Bestätigen</string>
     <string name="group_to_enter_button_enter_to_group">Der Gruppe beitreten</string>
     <string name="group_to_enter_textfield_token_to_grup">Gruppen-Token</string>
+    <string name="group_to_enter_divider">oder</string>
+    <string name="group_to_enter_scan_qr_code">QR-Code scannen</string>
+    <string name="group_to_enter_scan_prompt">Richte deine Kamera auf den QR-Code der Gruppe</string>
 
     <!-- Error State -->
     <string name="error_component_button_try_again">Erneut versuchen</string>

--- a/features/group/list/src/main/res/values-es/strings.xml
+++ b/features/group/list/src/main/res/values-es/strings.xml
@@ -32,6 +32,9 @@
     <string name="group_to_enter_button_text">Validar</string>
     <string name="group_to_enter_button_enter_to_group">Entrar al grupo</string>
     <string name="group_to_enter_textfield_token_to_grup">Token del grupo</string>
+    <string name="group_to_enter_divider">o</string>
+    <string name="group_to_enter_scan_qr_code">Escanear código QR</string>
+    <string name="group_to_enter_scan_prompt">Apunta la cámara al código QR del grupo</string>
 
     <!-- Error State -->
     <string name="error_component_button_try_again">Reintentar</string>

--- a/features/group/list/src/main/res/values-fr/strings.xml
+++ b/features/group/list/src/main/res/values-fr/strings.xml
@@ -31,6 +31,9 @@
     <string name="group_to_enter_button_text">Valider</string>
     <string name="group_to_enter_button_enter_to_group">Rejoindre le groupe</string>
     <string name="group_to_enter_textfield_token_to_grup">Jeton du groupe</string>
+    <string name="group_to_enter_divider">ou</string>
+    <string name="group_to_enter_scan_qr_code">Scanner le code QR</string>
+    <string name="group_to_enter_scan_prompt">Pointez votre caméra vers le code QR du groupe</string>
 
     <!-- Error State -->
     <string name="error_component_button_try_again">Réessayer</string>

--- a/features/group/list/src/main/res/values-ko/strings.xml
+++ b/features/group/list/src/main/res/values-ko/strings.xml
@@ -32,6 +32,9 @@
     <string name="group_to_enter_button_text">확인</string>
     <string name="group_to_enter_button_enter_to_group">그룹 입장</string>
     <string name="group_to_enter_textfield_token_to_grup">그룹 토큰</string>
+    <string name="group_to_enter_divider">또는</string>
+    <string name="group_to_enter_scan_qr_code">QR 코드 스캔</string>
+    <string name="group_to_enter_scan_prompt">그룹의 QR 코드에 카메라를 비추세요</string>
 
     <!-- Error State -->
     <string name="error_component_button_try_again">다시 시도</string>

--- a/features/group/list/src/main/res/values-nl/strings.xml
+++ b/features/group/list/src/main/res/values-nl/strings.xml
@@ -31,6 +31,9 @@
     <string name="group_to_enter_button_text">Valideren</string>
     <string name="group_to_enter_button_enter_to_group">Groep binnengaan</string>
     <string name="group_to_enter_textfield_token_to_grup">Groepstoken</string>
+    <string name="group_to_enter_divider">of</string>
+    <string name="group_to_enter_scan_qr_code">QR-code scannen</string>
+    <string name="group_to_enter_scan_prompt">Richt je camera op de QR-code van de groep</string>
 
     <!-- Error State -->
     <string name="error_component_button_try_again">Opnieuw proberen</string>

--- a/features/group/list/src/main/res/values-pl/strings.xml
+++ b/features/group/list/src/main/res/values-pl/strings.xml
@@ -31,6 +31,9 @@
     <string name="group_to_enter_button_text">Zatwierdź</string>
     <string name="group_to_enter_button_enter_to_group">Wejdź do grupy</string>
     <string name="group_to_enter_textfield_token_to_grup">Token grupy</string>
+    <string name="group_to_enter_divider">lub</string>
+    <string name="group_to_enter_scan_qr_code">Zeskanuj kod QR</string>
+    <string name="group_to_enter_scan_prompt">Skieruj aparat na kod QR grupy</string>
 
     <!-- Error State -->
     <string name="error_component_button_try_again">Spróbuj ponownie</string>

--- a/features/group/list/src/main/res/values-pt-rBR/strings.xml
+++ b/features/group/list/src/main/res/values-pt-rBR/strings.xml
@@ -32,6 +32,9 @@
     <string name="group_to_enter_button_text">Validar</string>
     <string name="group_to_enter_button_enter_to_group">Entrar no grupo</string>
     <string name="group_to_enter_textfield_token_to_grup">Token do grupo</string>
+    <string name="group_to_enter_divider">ou</string>
+    <string name="group_to_enter_scan_qr_code">Escanear QR Code</string>
+    <string name="group_to_enter_scan_prompt">Aponte a câmera para o QR Code do grupo</string>
 
     <!-- Error State -->
     <string name="error_component_button_try_again">Tentar novamente</string>

--- a/features/group/list/src/main/res/values/strings.xml
+++ b/features/group/list/src/main/res/values/strings.xml
@@ -31,6 +31,9 @@
     <string name="group_to_enter_button_text">Validate</string>
     <string name="group_to_enter_button_enter_to_group">Enter the group</string>
     <string name="group_to_enter_textfield_token_to_grup">Group token</string>
+    <string name="group_to_enter_divider">or</string>
+    <string name="group_to_enter_scan_qr_code">Scan QR Code</string>
+    <string name="group_to_enter_scan_prompt">Point your camera at the group\'s QR code</string>
 
     <!-- Error State -->
     <string name="error_component_button_try_again">Try again</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,6 +59,7 @@ coreKtxVersion = "1.7.0"
 window = "1.5.1"
 workRuntimeKtx = "2.10.0"
 zxingCore = "3.5.3"
+zxingAndroidEmbedded = "4.3.0"
 
 [libraries]
 accompanist-systemuicontroller = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "accompanistSystemuicontroller" }
@@ -125,6 +126,7 @@ androidx-core = { group = "androidx.core", name = "core", version.ref = "core" }
 core-ktx = { group = "androidx.test", name = "core-ktx", version.ref = "coreKtxVersion" }
 androidx-window = { module = "androidx.window:window", version.ref = "window" }
 zxing-core = { module = "com.google.zxing:core", version.ref = "zxingCore" }
+zxing-android-embedded = { module = "com.journeyapps:zxing-android-embedded", version.ref = "zxingAndroidEmbedded" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Bug: action cards row broken
`GroupDetailsActions` (`features/group/details/.../GroupDetailsScreen.kt`) renders the 5 action cards (Invite, Card, QR Code, Chat, Draw) in a plain `Row`. Each `ActionIconCard` has a fixed `width(100.dp)` — 5 of them plus the Row's padding need ~530dp of width, more than virtually any phone screen (~360-412dp), and the `Row` had no scroll modifier at all. Result: the trailing card(s) get clipped off-screen and are unreachable.

Note the outer screen was already fine — `GroupDetailsContent` wraps everything (header, this actions row, description, members, footer) in a `LazyColumn`, so the screen already scrolls vertically. The actual missing axis was **horizontal**, scoped to this one inner `Row`.

**Fix:** wrap the `Row` in `Modifier.horizontalScroll(rememberScrollState())` so all 5 cards are reachable by swiping, and switch `Arrangement.SpaceEvenly` → `Arrangement.spacedBy(12.dp)` (SpaceEvenly doesn't make sense once content can exceed the viewport).

## Feature: scan a QR code to join a group
There was no way to join a group by scanning its QR code — `GroupToEnterBottomSheet` only accepted manual 8-character token entry. The app already *generates* that QR code (`QrCodeGenerator` in `features/group/details`, encoding the raw `group.token` via `com.google.zxing:core`), so this closes the loop.

Added `com.journeyapps:zxing-android-embedded:4.3.0` to `features/group/list` — it wraps zxing decoding plus a ready-made scanning `Activity` (with its own camera-permission handling) behind the AndroidX Activity Result API (`ScanContract`/`ScanOptions`), so no custom camera/permission code was needed.

`GroupToEnterBottomSheet` now shows a "Scan QR Code" button below the manual token field. A successful scan (`result.contents`, trimmed/uppercased) is routed through the same `submit()` path as manual entry, so it hits the same validation and error handling (e.g. an unrelated/garbage QR code just fails the normal "group not found" path, nothing scan-specific to handle).

New strings added to all 8 locales (en, es, ko, pt-rBR, fr, de, nl, pl): `group_to_enter_divider`, `group_to_enter_scan_qr_code`, `group_to_enter_scan_prompt`.

## Verification
- `./gradlew :features:group:list:compileDebugKotlin :features:group:details:compileDebugKotlin` — success.
- `./gradlew :features:group:list:lintDebug :features:group:details:lintDebug` — success, no new warnings (no `MissingTranslation`/`ExtraTranslation`).
- Not verified on-device (no emulator/device in this environment) — worth a manual pass: scroll through all 5 action cards on a small screen, and a real scan-to-join round trip (share a group's QR code, scan it from another device/account, confirm it joins).