### PR TITLE
fix(chat): persist chat history locally and stop auto-deleting it

### DIFF
--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/data/local/ChatMessageDao.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/data/local/ChatMessageDao.kt
@@ -12,6 +12,9 @@ interface ChatMessageDao {
     @Query("SELECT * FROM chat_messages WHERE groupId = :groupId ORDER BY timestamp ASC")
     fun getMessages(groupId: String): Flow<List<ChatMessage>>
 
+    @Query("SELECT MAX(timestamp) FROM chat_messages WHERE groupId = :groupId")
+    suspend fun getLastTimestamp(groupId: String): Long?
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertMessages(messages: List<ChatMessage>)
 

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/data/local/ChatMessageMapper.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/data/local/ChatMessageMapper.kt
@@ -1,0 +1,26 @@
+package br.com.brunocarvalhs.chat.app.data.local
+
+import br.com.brunocarvalhs.chat.app.data.model.ChatMessage
+import br.com.brunocarvalhs.core.domain.model.MessageModel
+
+internal fun MessageModel.toEntity(): ChatMessage = ChatMessage(
+    id = id,
+    groupId = groupId,
+    text = text,
+    timestamp = timestamp,
+    senderName = senderName,
+    senderId = senderId,
+    status = status,
+    reactions = reactions
+)
+
+internal fun ChatMessage.toDomain(): MessageModel = MessageModel(
+    id = id,
+    groupId = groupId,
+    text = text,
+    senderId = senderId,
+    senderName = senderName,
+    timestamp = timestamp,
+    status = status,
+    reactions = reactions
+)

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/data/repository/ChatRepositoryImpl.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/data/repository/ChatRepositoryImpl.kt
@@ -1,25 +1,53 @@
 package br.com.brunocarvalhs.chat.app.data.repository
 
+import br.com.brunocarvalhs.chat.app.data.local.ChatMessageDao
+import br.com.brunocarvalhs.chat.app.data.local.toDomain
+import br.com.brunocarvalhs.chat.app.data.local.toEntity
 import br.com.brunocarvalhs.chat.app.domain.repository.ChatRepository
 import br.com.brunocarvalhs.chat.app.domain.services.ChatService
 import br.com.brunocarvalhs.core.domain.model.MessageModel
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class ChatRepositoryImpl @Inject constructor(
-    private val chatService: ChatService
+    private val chatService: ChatService,
+    private val chatMessageDao: ChatMessageDao
 ) : ChatRepository {
 
-    override suspend fun getMessages(groupId: String): Flow<List<MessageModel>> {
-        return chatService.getMessages(groupId)
+    override suspend fun getMessages(groupId: String): Flow<List<MessageModel>> = flow {
+        coroutineScope {
+            launch {
+                // Local Room cache is the source of truth for the UI; only fetch
+                // messages newer than what we already have to avoid re-downloading
+                // (and re-billing) the whole history on every chat open.
+                val sinceTimestamp = chatMessageDao.getLastTimestamp(groupId) ?: 0L
+                chatService.getMessages(groupId, sinceTimestamp).collect { newMessages ->
+                    chatMessageDao.insertMessages(newMessages.map { it.toEntity() })
+                }
+            }
+            emitAll(
+                chatMessageDao.getMessages(groupId).map { entities ->
+                    entities.map { it.toDomain() }
+                }
+            )
+        }
     }
 
     override suspend fun sendMessage(groupId: String, message: MessageModel): Result<Unit> {
+        // Save locally first so the message survives even if the remote write fails or the app closes.
+        chatMessageDao.insertMessage(message.toEntity())
         return chatService.sendMessage(groupId, message)
     }
 
-    override suspend fun clearMessages(groupId: String): Result<Unit> {
-        return chatService.clearMessages(groupId)
+    override suspend fun clearMessages(groupId: String): Result<Unit> = runCatching {
+        // Clearing is a local, per-device action (like WhatsApp's "Clear Chat"):
+        // it never deletes data from Firebase, so other members keep their history.
+        chatMessageDao.clearMessages(groupId)
     }
 
     override suspend fun setReaction(

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/data/services/FirebaseRealtimeManager.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/data/services/FirebaseRealtimeManager.kt
@@ -18,45 +18,48 @@ class FirebaseRealtimeManager @Inject constructor(
     private val database: FirebaseDatabase
 ) : ChatService {
 
-    override fun getMessages(groupId: String): Flow<List<MessageModel>> = callbackFlow {
-        val query = database.getReference(PATH).child(groupId)
-            .limitToLast(LIMIT_TO_LAST)
-
-        val messages = mutableMapOf<String, MessageModel>()
-
-        val listener = object : ChildEventListener {
-            override fun onChildAdded(snapshot: DataSnapshot, previousChildName: String?) {
-                val map = snapshot.value as? Map<String, Any> ?: return
-                val message = map.toMessageModel(snapshot.key ?: EMPTY_STRING, groupId)
-                messages[snapshot.key ?: EMPTY_STRING] = message
-                trySend(messages.values.toList().sortedBy { it.timestamp })
+    override fun getMessages(groupId: String, sinceTimestamp: Long): Flow<List<MessageModel>> =
+        callbackFlow {
+            val reference = database.getReference(PATH).child(groupId)
+            val query = if (sinceTimestamp > 0) {
+                // Only pull messages newer than what is already cached locally,
+                // instead of re-downloading the whole history on every open.
+                reference.orderByChild(KEY_TIMESTAMP).startAt((sinceTimestamp + 1).toDouble())
+            } else {
+                reference.limitToLast(LIMIT_TO_LAST)
             }
 
-            override fun onChildChanged(snapshot: DataSnapshot, previousChildName: String?) {
-                val map = snapshot.value as? Map<String, Any> ?: return
-                val message = map.toMessageModel(snapshot.key ?: EMPTY_STRING, groupId)
-                messages[snapshot.key ?: EMPTY_STRING] = message
-                trySend(messages.values.toList().sortedBy { it.timestamp })
+            val listener = object : ChildEventListener {
+                override fun onChildAdded(snapshot: DataSnapshot, previousChildName: String?) {
+                    emitMessage(snapshot)
+                }
+
+                override fun onChildChanged(snapshot: DataSnapshot, previousChildName: String?) {
+                    emitMessage(snapshot)
+                }
+
+                override fun onChildRemoved(snapshot: DataSnapshot) {
+                    // No-op: chat clearing is a local, per-device action (see ClearMessagesUseCase).
+                }
+
+                override fun onChildMoved(snapshot: DataSnapshot, previousChildName: String?) {
+                    // No-op: Child moved is not relevant for this message list
+                }
+
+                override fun onCancelled(error: DatabaseError) {
+                    Timber.e(error.toException())
+                    close(error.toException())
+                }
+
+                private fun emitMessage(snapshot: DataSnapshot) {
+                    val map = snapshot.value as? Map<String, Any> ?: return
+                    trySend(listOf(map.toMessageModel(snapshot.key ?: EMPTY_STRING, groupId)))
+                }
             }
 
-            override fun onChildRemoved(snapshot: DataSnapshot) {
-                messages.remove(snapshot.key)
-                trySend(messages.values.toList().sortedBy { it.timestamp })
-            }
-
-            override fun onChildMoved(snapshot: DataSnapshot, previousChildName: String?) {
-                // No-op: Child moved is not relevant for this message list
-            }
-
-            override fun onCancelled(error: DatabaseError) {
-                Timber.e(error.toException())
-                close(error.toException())
-            }
+            query.addChildEventListener(listener)
+            awaitClose { query.removeEventListener(listener) }
         }
-
-        query.addChildEventListener(listener)
-        awaitClose { query.removeEventListener(listener) }
-    }
 
     override suspend fun sendMessage(groupId: String, message: MessageModel): Result<Unit> =
         runCatching {
@@ -125,7 +128,7 @@ class FirebaseRealtimeManager @Inject constructor(
         const val KEY_TIMESTAMP = "ts"
         const val KEY_STATUS = "s"
         const val KEY_REACTIONS = "r"
-        const val LIMIT_TO_LAST = 20
+        const val LIMIT_TO_LAST = 200
         const val EMPTY_STRING = ""
     }
 }

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/domain/services/ChatService.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/domain/services/ChatService.kt
@@ -4,7 +4,7 @@ import br.com.brunocarvalhs.core.domain.model.MessageModel
 import kotlinx.coroutines.flow.Flow
 
 interface ChatService {
-    fun getMessages(groupId: String): Flow<List<MessageModel>>
+    fun getMessages(groupId: String, sinceTimestamp: Long = 0L): Flow<List<MessageModel>>
     suspend fun sendMessage(groupId: String, message: MessageModel): Result<Unit>
     suspend fun clearMessages(groupId: String): Result<Unit>
     suspend fun setReaction(

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/ChatViewModel.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/ChatViewModel.kt
@@ -27,10 +27,6 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import timber.log.Timber
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
 import java.util.UUID
 import javax.inject.Inject
 
@@ -73,8 +69,6 @@ internal class ChatViewModel @Inject constructor(
         viewModelScope.launch {
             deviceId = deviceService.getDeviceId()
 
-            checkAndClearExpiredChat()
-
             val cachedName = identifyUserUseCase.getNickname()
             val member =
                 _uiState.value.groupModel.members.find { it.phoneNumber == deviceId || it.id == deviceId }
@@ -90,27 +84,6 @@ internal class ChatViewModel @Inject constructor(
         }
     }
 
-    @AddTrace(name = "ChatViewModel.checkAndClearExpiredChat", enabled = true)
-    private suspend fun checkAndClearExpiredChat() {
-        analyticsService.logEvent(
-            name = AnalyticsEvent.VIEW,
-            params = mapOf(
-                AnalyticsParam.ACTION to "check_and_clear_expired_chat"
-            )
-        )
-        val groupDateString = _uiState.value.groupModel.date ?: return
-        runCatching {
-            val sdf = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
-            val groupDate = sdf.parse(groupDateString) ?: return
-            val currentDate = Date()
-
-            if (currentDate.after(groupDate)) {
-                Timber.d("Chat expirado para o grupo ${_uiState.value.groupModel.id}. Limpando...")
-                clearMessagesUseCase(_uiState.value.groupModel.id)
-            }
-        }.onFailure { Timber.e(it) }
-    }
-
     @AddTrace(name = "ChatViewModel.handleIntent", enabled = true)
     fun handleIntent(intent: ChatIntent) {
         when (intent) {
@@ -119,8 +92,21 @@ internal class ChatViewModel @Inject constructor(
             is ChatIntent.LoadMessages -> observeMessages()
             is ChatIntent.IdentifyUser -> identifyUser(intent.name)
             is ChatIntent.DismissIdentification -> _uiState.update { it.copy(showIdentificationModal = false) }
-            is ChatIntent.ClearChat -> {}
+            is ChatIntent.ClearChat -> clearChat()
             is ChatIntent.ToggleReaction -> toggleReaction(intent.messageId, intent.emoji)
+        }
+    }
+
+    @AddTrace(name = "ChatViewModel.clearChat", enabled = true)
+    private fun clearChat() {
+        analyticsService.logEvent(
+            name = AnalyticsEvent.SUBMIT,
+            params = mapOf(
+                AnalyticsParam.ACTION to "clear_chat"
+            )
+        )
+        viewModelScope.launch {
+            clearMessagesUseCase(_uiState.value.groupModel.id)
         }
     }
 

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/commons/di/ChatModule.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/commons/di/ChatModule.kt
@@ -1,6 +1,10 @@
 package br.com.brunocarvalhs.chat.commons.di
 
+import android.content.Context
+import androidx.room.Room
 import br.com.brunocarvalhs.chat.ChatInitializerImpl
+import br.com.brunocarvalhs.chat.app.data.local.ChatDatabase
+import br.com.brunocarvalhs.chat.app.data.local.ChatMessageDao
 import br.com.brunocarvalhs.chat.app.data.repository.ChatRepositoryImpl
 import br.com.brunocarvalhs.chat.app.data.services.FirebaseRealtimeManager
 import br.com.brunocarvalhs.chat.app.domain.repository.ChatRepository
@@ -11,6 +15,7 @@ import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import javax.inject.Singleton
@@ -40,6 +45,17 @@ abstract class ChatModule {
         @Singleton
         fun provideFirebaseDatabase(): FirebaseDatabase {
             return FirebaseDatabase.getInstance()
+        }
+
+        @Provides
+        @Singleton
+        fun provideChatDatabase(@ApplicationContext context: Context): ChatDatabase {
+            return Room.databaseBuilder(context, ChatDatabase::class.java, "chat.db").build()
+        }
+
+        @Provides
+        fun provideChatMessageDao(database: ChatDatabase): ChatMessageDao {
+            return database.chatMessageDao()
         }
     }
 }

--- a/features/chat/src/test/java/br/com/brunocarvalhs/chat/app/data/repository/ChatRepositoryImplTest.kt
+++ b/features/chat/src/test/java/br/com/brunocarvalhs/chat/app/data/repository/ChatRepositoryImplTest.kt
@@ -1,12 +1,16 @@
 package br.com.brunocarvalhs.chat.app.data.repository
 
+import br.com.brunocarvalhs.chat.app.data.local.ChatMessageDao
+import br.com.brunocarvalhs.chat.app.data.local.toEntity
 import br.com.brunocarvalhs.chat.app.domain.services.ChatService
 import br.com.brunocarvalhs.core.domain.model.MessageModel
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -14,15 +18,16 @@ import org.junit.Test
 class ChatRepositoryImplTest {
 
     private val chatService: ChatService = mockk()
+    private val chatMessageDao: ChatMessageDao = mockk(relaxed = true)
     private lateinit var repository: ChatRepositoryImpl
 
     @Before
     fun setup() {
-        repository = ChatRepositoryImpl(chatService)
+        repository = ChatRepositoryImpl(chatService, chatMessageDao)
     }
 
     @Test
-    fun `sendMessage should call network and service`() = runTest {
+    fun `sendMessage should save locally and call the service`() = runTest {
         // Given
         val groupId = "group1"
         val message = MessageModel(id = "msg1", text = "Hello", groupId = groupId)
@@ -33,34 +38,68 @@ class ChatRepositoryImplTest {
 
         // Then
         assertTrue(result.isSuccess)
+        coVerify { chatMessageDao.insertMessage(message.toEntity()) }
         coVerify { chatService.sendMessage(groupId, message) }
     }
 
     @Test
-    fun `clearMessages should call network and service`() = runTest {
+    fun `clearMessages should only clear the local cache and not touch the remote service`() =
+        runTest {
+            // Given
+            val groupId = "group1"
+
+            // When
+            val result = repository.clearMessages(groupId)
+
+            // Then
+            assertTrue(result.isSuccess)
+            coVerify { chatMessageDao.clearMessages(groupId) }
+        }
+
+    @Test
+    fun `getMessages should fetch only messages newer than the local cache`() = runTest {
         // Given
         val groupId = "group1"
-        coEvery { chatService.clearMessages(groupId) } returns Result.success(Unit)
+        coEvery { chatMessageDao.getLastTimestamp(groupId) } returns 1000L
+        coEvery { chatService.getMessages(groupId, 1000L) } returns flowOf(emptyList())
+        coEvery { chatMessageDao.getMessages(groupId) } returns flowOf(emptyList())
 
         // When
-        val result = repository.clearMessages(groupId)
+        repository.getMessages(groupId).toList()
 
         // Then
-        assertTrue(result.isSuccess)
-        coVerify { chatService.clearMessages(groupId) }
+        coVerify { chatService.getMessages(groupId, 1000L) }
     }
 
     @Test
-    fun `getMessages should return flow from service`() = runTest {
+    fun `getMessages should fetch from scratch when there is no local cache`() = runTest {
+        // Given
         val groupId = "group1"
-        val expectedFlow = flowOf(emptyList<MessageModel>())
+        coEvery { chatMessageDao.getLastTimestamp(groupId) } returns null
+        coEvery { chatService.getMessages(groupId, 0L) } returns flowOf(emptyList())
+        coEvery { chatMessageDao.getMessages(groupId) } returns flowOf(emptyList())
 
-        coEvery { chatService.getMessages(groupId) } returns expectedFlow
+        // When
+        repository.getMessages(groupId).toList()
 
-        val result = repository.getMessages(groupId)
+        // Then
+        coVerify { chatService.getMessages(groupId, 0L) }
+    }
 
-        assertTrue(result === expectedFlow)
-        coVerify { chatService.getMessages(groupId) }
+    @Test
+    fun `getMessages should return the local cache mapped to the domain model`() = runTest {
+        // Given
+        val groupId = "group1"
+        val message = MessageModel(id = "msg1", text = "Hello", groupId = groupId, timestamp = 500L)
+        coEvery { chatMessageDao.getLastTimestamp(groupId) } returns null
+        coEvery { chatService.getMessages(groupId, 0L) } returns flowOf(emptyList())
+        coEvery { chatMessageDao.getMessages(groupId) } returns flowOf(listOf(message.toEntity()))
+
+        // When
+        val result = repository.getMessages(groupId).toList()
+
+        // Then
+        assertEquals(listOf(message), result.first())
     }
 
     @Test


### PR DESCRIPTION
## Summary
- O chat não tinha cache local: reabrir dependia 100% de um novo round-trip com o Firebase Realtime Database, então o histórico parecia sumir (ou ficava vazio offline).
- Além disso, o chat apagava **automaticamente** todas as mensagens do Firebase assim que alguém abria a conversa depois da data do amigo secreto já ter passado — sem volta.
- Conecta o banco Room (`ChatDatabase`/`ChatMessageDao`) que já existia no código mas nunca tinha sido plugado em lugar nenhum, e o transforma na fonte de verdade local do chat: o histórico agora carrega na hora e sobrevive offline, como no WhatsApp.
- Sincroniza só as mensagens mais novas que o que já está em cache local (em vez de rebaixar tudo de novo a cada abertura), para reduzir custo de leitura/banda do Firebase.
- Mensagens enviadas agora são salvas localmente antes da escrita remota, então não se perdem se o envio falhar ou o app fechar.
- Remove a limpeza automática por data; "limpar conversa" agora é uma ação explícita e **local** (não apaga nada do Firebase, então os outros membros mantêm o histórico deles).

## Test plan
- [x] `./gradlew :features:chat:compileDebugKotlin` — compila sem erros
- [x] `./gradlew :features:chat:testDebugUnitTest` — `ChatRepositoryImplTest` (reescrito para a nova arquitetura) passa 100%; as únicas falhas remanescentes (`ChatDatabaseTest`, `NavTypeSerializerTest`) são pré-existentes, causadas por incompatibilidade do JDK local (26) com o Robolectric, não relacionadas a esta mudança
- [ ] Teste manual: abrir um chat, enviar mensagens, fechar e reabrir o app — histórico deve aparecer instantaneamente, inclusive offline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDd6WxKNjnPHjvPpiqyYN2