### PR TITLE
fix(chat): keep input above the navigation bar and add WhatsApp-style date dividers

### DIFF
--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/data/extensions/FormatDate.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/data/extensions/FormatDate.kt
@@ -1,6 +1,7 @@
 package br.com.brunocarvalhs.chat.app.data.extensions
 
 import java.text.SimpleDateFormat
+import java.util.Calendar
 import java.util.Locale
 
 private const val PATTERN_DATE = "HH:mm"
@@ -8,4 +9,11 @@ private const val PATTERN_DATE = "HH:mm"
 internal fun Long.toLocalDateTime(): String {
     return SimpleDateFormat(PATTERN_DATE, Locale.getDefault())
         .format(java.util.Date(this))
+}
+
+internal fun Long.isSameDayAs(other: Long): Boolean {
+    val calendar = Calendar.getInstance().apply { timeInMillis = this@isSameDayAs }
+    val otherCalendar = Calendar.getInstance().apply { timeInMillis = other }
+    return calendar.get(Calendar.YEAR) == otherCalendar.get(Calendar.YEAR) &&
+        calendar.get(Calendar.DAY_OF_YEAR) == otherCalendar.get(Calendar.DAY_OF_YEAR)
 }

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/ChatScreen.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/ChatScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -60,11 +62,34 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import br.com.brunocarvalhs.chat.R
+import br.com.brunocarvalhs.chat.app.data.extensions.isSameDayAs
 import br.com.brunocarvalhs.chat.app.data.extensions.toLocalDateTime
 import br.com.brunocarvalhs.chat.app.data.model.ChatMessage
 import br.com.brunocarvalhs.core.domain.model.MessageModel.MessageStatus
+import java.text.DateFormat
+import java.util.Date
+import java.util.Locale
 
 private val QUICK_REACTIONS = listOf("👍", "❤️", "😂", "🎁", "😮")
+private const val DAY_IN_MILLIS = 24 * 60 * 60 * 1000L
+
+private sealed class ChatListItem {
+    data class DateHeader(val timestamp: Long) : ChatListItem()
+    data class Message(val chatMessage: ChatMessage) : ChatListItem()
+}
+
+private fun List<ChatMessage>.withDateHeaders(): List<ChatListItem> {
+    val result = mutableListOf<ChatListItem>()
+    var lastTimestamp: Long? = null
+    for (message in this) {
+        if (lastTimestamp == null || !message.timestamp.isSameDayAs(lastTimestamp)) {
+            result.add(ChatListItem.DateHeader(message.timestamp))
+            lastTimestamp = message.timestamp
+        }
+        result.add(ChatListItem.Message(message))
+    }
+    return result
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -118,6 +143,8 @@ internal fun ChatScreen(
                 .fillMaxSize()
                 .padding(paddingValues)
         ) {
+            val itemsWithHeaders = remember(state.messages) { state.messages.withDateHeaders() }
+
             LazyColumn(
                 state = listState,
                 modifier = Modifier
@@ -125,13 +152,26 @@ internal fun ChatScreen(
                     .fillMaxWidth(),
                 contentPadding = PaddingValues(16.dp)
             ) {
-                items(state.messages, key = { it.id }) { message ->
-                    ChatMessageItem(
-                        message = message,
-                        onToggleReaction = { emoji ->
-                            viewModel.handleIntent(ChatIntent.ToggleReaction(message.id, emoji))
+                items(
+                    itemsWithHeaders,
+                    key = {
+                        when (it) {
+                            is ChatListItem.DateHeader -> "header_${it.timestamp}"
+                            is ChatListItem.Message -> it.chatMessage.id
                         }
-                    )
+                    }
+                ) { item ->
+                    when (item) {
+                        is ChatListItem.DateHeader -> ChatDateDivider(timestamp = item.timestamp)
+                        is ChatListItem.Message -> ChatMessageItem(
+                            message = item.chatMessage,
+                            onToggleReaction = { emoji ->
+                                viewModel.handleIntent(
+                                    ChatIntent.ToggleReaction(item.chatMessage.id, emoji)
+                                )
+                            }
+                        )
+                    }
                 }
             }
         }
@@ -179,6 +219,41 @@ fun IdentificationDialog(
             }
         }
     )
+}
+
+@Composable
+private fun ChatDateDivider(
+    timestamp: Long,
+    modifier: Modifier = Modifier
+) {
+    val now = remember { System.currentTimeMillis() }
+    val label = when {
+        timestamp.isSameDayAs(now) -> stringResource(R.string.chat_date_today)
+        timestamp.isSameDayAs(now - DAY_IN_MILLIS) -> stringResource(R.string.chat_date_yesterday)
+        else -> remember(timestamp) {
+            DateFormat.getDateInstance(DateFormat.MEDIUM, Locale.getDefault())
+                .format(Date(timestamp))
+        }
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Surface(
+            shape = RoundedCornerShape(8.dp),
+            color = MaterialTheme.colorScheme.surfaceVariant
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp)
+            )
+        }
+    }
 }
 
 @Composable
@@ -349,7 +424,9 @@ fun ChatInputBar(
     modifier: Modifier = Modifier
 ) {
     Surface(
-        modifier = modifier,
+        modifier = modifier
+            .navigationBarsPadding()
+            .imePadding(),
         tonalElevation = 2.dp
     ) {
         Row(

--- a/features/chat/src/main/res/values-de/strings.xml
+++ b/features/chat/src/main/res/values-de/strings.xml
@@ -9,4 +9,6 @@
     <string name="chat_input">Nachricht schreiben...</string>
     <string name="chat_button_send">Senden</string>
     <string name="react_to_message">Auf Nachricht reagieren</string>
+    <string name="chat_date_today">Heute</string>
+    <string name="chat_date_yesterday">Gestern</string>
 </resources>

--- a/features/chat/src/main/res/values-es/strings.xml
+++ b/features/chat/src/main/res/values-es/strings.xml
@@ -9,4 +9,6 @@
     <string name="chat_input">Escribe un mensaje...</string>
     <string name="chat_button_send">Enviar</string>
     <string name="react_to_message">Reaccionar al mensaje</string>
+    <string name="chat_date_today">Hoy</string>
+    <string name="chat_date_yesterday">Ayer</string>
 </resources>

--- a/features/chat/src/main/res/values-fr/strings.xml
+++ b/features/chat/src/main/res/values-fr/strings.xml
@@ -9,4 +9,6 @@
     <string name="chat_input">Écrivez un message...</string>
     <string name="chat_button_send">Envoyer</string>
     <string name="react_to_message">Réagir au message</string>
+    <string name="chat_date_today">Aujourd\'hui</string>
+    <string name="chat_date_yesterday">Hier</string>
 </resources>

--- a/features/chat/src/main/res/values-ko/strings.xml
+++ b/features/chat/src/main/res/values-ko/strings.xml
@@ -9,4 +9,6 @@
     <string name="chat_input">메시지 입력...</string>
     <string name="chat_button_send">전송</string>
     <string name="react_to_message">메시지에 반응하기</string>
+    <string name="chat_date_today">오늘</string>
+    <string name="chat_date_yesterday">어제</string>
 </resources>

--- a/features/chat/src/main/res/values-nl/strings.xml
+++ b/features/chat/src/main/res/values-nl/strings.xml
@@ -9,4 +9,6 @@
     <string name="chat_input">Typ een bericht...</string>
     <string name="chat_button_send">Versturen</string>
     <string name="react_to_message">Reageren op bericht</string>
+    <string name="chat_date_today">Vandaag</string>
+    <string name="chat_date_yesterday">Gisteren</string>
 </resources>

--- a/features/chat/src/main/res/values-pl/strings.xml
+++ b/features/chat/src/main/res/values-pl/strings.xml
@@ -9,4 +9,6 @@
     <string name="chat_input">Napisz wiadomość...</string>
     <string name="chat_button_send">Wyślij</string>
     <string name="react_to_message">Zareaguj na wiadomość</string>
+    <string name="chat_date_today">Dzisiaj</string>
+    <string name="chat_date_yesterday">Wczoraj</string>
 </resources>

--- a/features/chat/src/main/res/values-pt-rBR/strings.xml
+++ b/features/chat/src/main/res/values-pt-rBR/strings.xml
@@ -9,4 +9,6 @@
     <string name="chat_input">Digite uma mensagem...</string>
     <string name="chat_button_send">Enviar</string>
     <string name="react_to_message">Reagir à mensagem</string>
+    <string name="chat_date_today">Hoje</string>
+    <string name="chat_date_yesterday">Ontem</string>
 </resources>

--- a/features/chat/src/main/res/values/strings.xml
+++ b/features/chat/src/main/res/values/strings.xml
@@ -9,4 +9,6 @@
     <string name="chat_input">Type a message...</string>
     <string name="chat_button_send">Send</string>
     <string name="react_to_message">React to message</string>
+    <string name="chat_date_today">Today</string>
+    <string name="chat_date_yesterday">Yesterday</string>
 </resources>


### PR DESCRIPTION
## Summary
- O campo de digitação do chat ficava atrás da barra de navegação do sistema em dispositivos edge-to-edge (nenhum insets era aplicado ao `ChatInputBar`).
- Adiciona `navigationBarsPadding()`/`imePadding()` no input para ele nunca ficar escondido atrás da nav bar ou do teclado.
- Adiciona separadores de data ("Hoje" / "Ontem" / data) entre grupos de mensagens de dias diferentes, no estilo WhatsApp.

## Test plan
- [x] `./gradlew :features:chat:compileDebugKotlin` — compila sem erros
- [x] `./gradlew :features:chat:testDebugUnitTest` — mesmas 6 falhas pré-existentes de ambiente (Robolectric + JDK 26 local), nenhuma nova falha
- [ ] Teste manual: abrir o chat em um dispositivo/emulador com gesture navigation e confirmar que o input não fica atrás da barra; enviar mensagens em dias diferentes e confirmar o separador de data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDd6WxKNjnPHjvPpiqyYN2