### PR TITLE
feat(group-details): consolidate invite actions into a bottom sheet

### DIFF
--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsScreen.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsScreen.kt
@@ -30,9 +30,6 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.NotificationsActive
 import androidx.compose.material.icons.filled.NotificationsNone
 import androidx.compose.material.icons.filled.PersonAdd
-import androidx.compose.material.icons.filled.QrCode
-import androidx.compose.material.icons.filled.Share
-import androidx.compose.material.icons.filled.Wallpaper
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -70,6 +67,7 @@ import br.com.brunocarvalhs.core.domain.model.UserModel
 import br.com.brunocarvalhs.group.details.R
 import br.com.brunocarvalhs.group.details.app.presentation.components.ActionIconCard
 import br.com.brunocarvalhs.group.details.app.presentation.components.EditLikesDialog
+import br.com.brunocarvalhs.group.details.app.presentation.components.InviteBottomSheet
 import br.com.brunocarvalhs.group.details.app.presentation.components.MemberItem
 import br.com.brunocarvalhs.group.details.app.presentation.components.SectionHeader
 import br.com.brunocarvalhs.group.details.app.presentation.components.SettingItem
@@ -93,6 +91,7 @@ internal fun GroupDetailsScreen(
     val group = uiState.group
     var memberPendingRemoval by remember { mutableStateOf<UserModel?>(null) }
     var editingLikesMember by remember { mutableStateOf<UserModel?>(null) }
+    var showInviteSheet by remember { mutableStateOf(false) }
 
     val notificationPermissionState = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         rememberPermissionState(Manifest.permission.POST_NOTIFICATIONS)
@@ -132,9 +131,7 @@ internal fun GroupDetailsScreen(
         onDraw = { onDraw.invoke(group) },
         onChat = { onChat.invoke(group) },
         onDelete = { viewModel.handleIntent(GroupDetailsIntent.Delete(onBack)) },
-        onShareGroup = { viewModel.handleIntent(GroupDetailsIntent.Share) },
-        onShareInviteCard = { viewModel.handleIntent(GroupDetailsIntent.ShareInviteCard) },
-        onShareQrCode = { viewModel.handleIntent(GroupDetailsIntent.ShareQr) },
+        onInviteClick = { showInviteSheet = true },
         onExit = { viewModel.handleIntent(GroupDetailsIntent.Exit(onBack)) },
         onEdit = { onEdit.invoke(group) },
         onAddMembers = { onAddMembers.invoke(group) },
@@ -188,6 +185,14 @@ internal fun GroupDetailsScreen(
             }
         )
     }
+
+    if (showInviteSheet) {
+        InviteBottomSheet(
+            onDismiss = { showInviteSheet = false },
+            onShareLink = { viewModel.handleIntent(GroupDetailsIntent.Share) },
+            onShareQrCode = { viewModel.handleIntent(GroupDetailsIntent.ShareQr) }
+        )
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -210,9 +215,7 @@ private fun GroupDetailsContent(
     onChat: () -> Unit,
     onDelete: () -> Unit,
     onExit: () -> Unit,
-    onShareGroup: () -> Unit,
-    onShareInviteCard: () -> Unit,
-    onShareQrCode: () -> Unit,
+    onInviteClick: () -> Unit,
     onEdit: () -> Unit,
     onAddMembers: () -> Unit,
     isReminderEnabled: Boolean = false,
@@ -244,9 +247,7 @@ private fun GroupDetailsContent(
             item {
                 GroupDetailsActions(
                     isDrawn = isDrawn,
-                    onShareGroup = onShareGroup,
-                    onShareInviteCard = onShareInviteCard,
-                    onShareQrCode = onShareQrCode,
+                    onInviteClick = onInviteClick,
                     onChat = onChat,
                     onDraw = onDraw
                 )
@@ -371,9 +372,7 @@ private fun GroupDetailsHeader(
 @Composable
 private fun GroupDetailsActions(
     isDrawn: Boolean,
-    onShareGroup: () -> Unit,
-    onShareInviteCard: () -> Unit,
-    onShareQrCode: () -> Unit,
+    onInviteClick: () -> Unit,
     onChat: () -> Unit,
     onDraw: () -> Unit
 ) {
@@ -386,16 +385,8 @@ private fun GroupDetailsActions(
             horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             ActionIconCard(
-                Icons.Default.Share,
-                stringResource(R.string.invite), onShareGroup
-            )
-            ActionIconCard(
-                Icons.Default.Wallpaper,
-                stringResource(R.string.invite_card), onShareInviteCard
-            )
-            ActionIconCard(
-                Icons.Default.QrCode,
-                stringResource(R.string.qr_code), onShareQrCode
+                Icons.Default.PersonAdd,
+                stringResource(R.string.invite), onInviteClick
             )
             ActionIconCard(
                 Icons.AutoMirrored.Filled.Chat,
@@ -592,9 +583,7 @@ private fun GroupDetailsPreview() {
         onChat = {},
         onDelete = {},
         onExit = {},
-        onShareGroup = {},
-        onShareInviteCard = {},
-        onShareQrCode = {},
+        onInviteClick = {},
         onEdit = {},
         onAddMembers = {}
     )

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/components/InviteBottomSheet.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/components/InviteBottomSheet.kt
@@ -1,0 +1,127 @@
+package br.com.brunocarvalhs.group.details.app.presentation.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.QrCode
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import br.com.brunocarvalhs.group.details.R
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun InviteBottomSheet(
+    onDismiss: () -> Unit,
+    onShareLink: () -> Unit,
+    onShareQrCode: () -> Unit,
+) {
+    val scope = rememberCoroutineScope()
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    fun dismissAndRun(action: () -> Unit) {
+        scope.launch {
+            sheetState.hide()
+        }.invokeOnCompletion {
+            if (!sheetState.isVisible) {
+                onDismiss()
+            }
+            action()
+        }
+    }
+
+    ModalBottomSheet(
+        modifier = Modifier.fillMaxWidth(),
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        dragHandle = {
+            BottomSheetDefaults.DragHandle(
+                modifier = Modifier
+                    .padding(vertical = 8.dp)
+                    .width(40.dp)
+            )
+        }
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.invite),
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+            InviteOptionRow(
+                icon = Icons.Default.Share,
+                title = stringResource(R.string.invite_share_link_title),
+                description = stringResource(R.string.invite_share_link_description),
+                onClick = { dismissAndRun(onShareLink) }
+            )
+            InviteOptionRow(
+                icon = Icons.Default.QrCode,
+                title = stringResource(R.string.qr_code),
+                description = stringResource(R.string.invite_share_qr_description),
+                onClick = { dismissAndRun(onShareQrCode) }
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun InviteOptionRow(
+    icon: ImageVector,
+    title: String,
+    description: String,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .clickable(onClick = onClick)
+            .padding(vertical = 12.dp, horizontal = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(28.dp)
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+        Column {
+            Text(text = title, style = MaterialTheme.typography.bodyLarge)
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}

--- a/features/group/details/src/main/res/values-de/strings.xml
+++ b/features/group/details/src/main/res/values-de/strings.xml
@@ -32,6 +32,9 @@
     <string name="share_group_title">Code teilen</string>
     <string name="invite_card">Karte</string>
     <string name="qr_code">QR-Code</string>
+    <string name="invite_share_link_title">Link teilen</string>
+    <string name="invite_share_link_description">Sende einen Einladungslink oder Text über eine beliebige App</string>
+    <string name="invite_share_qr_description">Teile einen QR-Code, den andere scannen können, um beizutreten</string>
     <string name="reminder_enable_action">An den Auslosungstermin erinnern</string>
     <string name="reminder_disable_action">Erinnerung ausschalten</string>
     <string name="reminder_notification_channel_name">Wichtel-Erinnerungen</string>

--- a/features/group/details/src/main/res/values-es/strings.xml
+++ b/features/group/details/src/main/res/values-es/strings.xml
@@ -32,6 +32,9 @@
     <string name="share_group_title">Compartir código</string>
     <string name="invite_card">Tarjeta</string>
     <string name="qr_code">Código QR</string>
+    <string name="invite_share_link_title">Compartir enlace</string>
+    <string name="invite_share_link_description">Envía un enlace de invitación o texto a través de cualquier app</string>
+    <string name="invite_share_qr_description">Comparte un código QR que otros puedan escanear para unirse</string>
     <string name="reminder_enable_action">Recordarme en la fecha del sorteo</string>
     <string name="reminder_disable_action">Desactivar recordatorio</string>
     <string name="reminder_notification_channel_name">Recordatorios de Amigo Invisible</string>

--- a/features/group/details/src/main/res/values-fr/strings.xml
+++ b/features/group/details/src/main/res/values-fr/strings.xml
@@ -32,6 +32,9 @@
     <string name="share_group_title">Partager le code</string>
     <string name="invite_card">Carte</string>
     <string name="qr_code">Code QR</string>
+    <string name="invite_share_link_title">Partager le lien</string>
+    <string name="invite_share_link_description">Envoyez un lien d\'invitation ou un texte via n\'importe quelle application</string>
+    <string name="invite_share_qr_description">Partagez un code QR que d\'autres peuvent scanner pour rejoindre</string>
     <string name="reminder_enable_action">Me rappeler à la date du tirage</string>
     <string name="reminder_disable_action">Désactiver le rappel</string>
     <string name="reminder_notification_channel_name">Rappels du Père Noël secret</string>

--- a/features/group/details/src/main/res/values-ko/strings.xml
+++ b/features/group/details/src/main/res/values-ko/strings.xml
@@ -32,6 +32,9 @@
     <string name="share_group_title">코드 공유</string>
     <string name="invite_card">카드</string>
     <string name="qr_code">QR 코드</string>
+    <string name="invite_share_link_title">링크 공유</string>
+    <string name="invite_share_link_description">원하는 앱으로 초대 링크나 텍스트를 보내세요</string>
+    <string name="invite_share_qr_description">다른 사람이 스캔해서 참여할 수 있는 QR 코드를 공유하세요</string>
     <string name="reminder_enable_action">추첨일에 알림 받기</string>
     <string name="reminder_disable_action">알림 끄기</string>
     <string name="reminder_notification_channel_name">시크릿 산타 알림</string>

--- a/features/group/details/src/main/res/values-nl/strings.xml
+++ b/features/group/details/src/main/res/values-nl/strings.xml
@@ -32,6 +32,9 @@
     <string name="share_group_title">Code delen</string>
     <string name="invite_card">Kaart</string>
     <string name="qr_code">QR-code</string>
+    <string name="invite_share_link_title">Link delen</string>
+    <string name="invite_share_link_description">Stuur een uitnodigingslink of tekst via een willekeurige app</string>
+    <string name="invite_share_qr_description">Deel een QR-code die anderen kunnen scannen om lid te worden</string>
     <string name="reminder_enable_action">Herinner me op de datum van de loting</string>
     <string name="reminder_disable_action">Herinnering uitzetten</string>
     <string name="reminder_notification_channel_name">Geheime Lootjes-herinneringen</string>

--- a/features/group/details/src/main/res/values-pl/strings.xml
+++ b/features/group/details/src/main/res/values-pl/strings.xml
@@ -32,6 +32,9 @@
     <string name="share_group_title">Udostępnij kod</string>
     <string name="invite_card">Karta</string>
     <string name="qr_code">Kod QR</string>
+    <string name="invite_share_link_title">Udostępnij link</string>
+    <string name="invite_share_link_description">Wyślij link zaproszenia lub tekst przez dowolną aplikację</string>
+    <string name="invite_share_qr_description">Udostępnij kod QR, który inni mogą zeskanować, aby dołączyć</string>
     <string name="reminder_enable_action">Przypomnij mi w dniu losowania</string>
     <string name="reminder_disable_action">Wyłącz przypomnienie</string>
     <string name="reminder_notification_channel_name">Przypomnienia Sekretnego Mikołaja</string>

--- a/features/group/details/src/main/res/values-pt-rBR/strings.xml
+++ b/features/group/details/src/main/res/values-pt-rBR/strings.xml
@@ -32,6 +32,9 @@
     <string name="share_group_title">Compartilhar Código</string>
     <string name="invite_card">Cartão</string>
     <string name="qr_code">QR Code</string>
+    <string name="invite_share_link_title">Compartilhar link</string>
+    <string name="invite_share_link_description">Envie um link ou texto de convite por qualquer app</string>
+    <string name="invite_share_qr_description">Compartilhe um QR Code para outros escanearem e entrarem</string>
     <string name="reminder_enable_action">Lembrar na data do sorteio</string>
     <string name="reminder_disable_action">Desativar lembrete</string>
     <string name="reminder_notification_channel_name">Lembretes de Amigo Secreto</string>

--- a/features/group/details/src/main/res/values/strings.xml
+++ b/features/group/details/src/main/res/values/strings.xml
@@ -32,6 +32,9 @@
     <string name="share_group_title">Share Code</string>
     <string name="invite_card">Card</string>
     <string name="qr_code">QR Code</string>
+    <string name="invite_share_link_title">Share link</string>
+    <string name="invite_share_link_description">Send an invite link or text through any app</string>
+    <string name="invite_share_qr_description">Share a QR code others can scan to join</string>
     <string name="reminder_enable_action">Remind me on the draw date</string>
     <string name="reminder_disable_action">Turn off reminder</string>
     <string name="reminder_notification_channel_name">Secret Santa reminders</string>


### PR DESCRIPTION
## Summary
- A tela de detalhes do grupo tinha 3 cards separados para convidar (compartilhar link, compartilhar cartão-imagem, compartilhar QR Code), poluindo a linha de ações.
- Substitui os 3 cards por um único botão "Convidar".
- Ao tocar, abre um bottom sheet com 2 opções: compartilhar link ou QR Code — seguindo o mesmo padrão de `ModalBottomSheet` já usado em `GroupToEnterBottomSheet`.
- O compartilhamento do cartão-convite ilustrado (`ShareGroupInviteCardUseCase`) continua funcional no ViewModel, só não está mais acessível por essa tela — dá pra reintroduzir depois (ex: como 3ª opção do sheet) se fizer sentido.

## Test plan
- [x] `./gradlew :features:group:details:compileDebugKotlin` — compila sem erros
- [x] `./gradlew :features:group:details:testDebugUnitTest` — as 18 falhas são as mesmas pré-existentes de ambiente (Robolectric + JDK 26 local), em arquivos que não toquei; nenhuma nova falha
- [ ] Teste manual: abrir detalhes de um grupo, tocar em "Convidar", confirmar que o sheet abre com as 2 opções e cada uma aciona o compartilhamento correto

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDd6WxKNjnPHjvPpiqyYN2