### PR TITLE
feat(group-details): let group members add adjectives to each other

### DIFF
--- a/core/domain/src/main/java/br/com/brunocarvalhs/core/domain/model/UserModel.kt
+++ b/core/domain/src/main/java/br/com/brunocarvalhs/core/domain/model/UserModel.kt
@@ -9,7 +9,8 @@ data class UserModel(
     val name: String = "",
     val phoneNumber: String = "",
     val photoUrl: String? = null,
-    val likes: List<String> = emptyList()
+    val likes: List<String> = emptyList(),
+    val adjectives: Map<String, List<String>> = emptyMap()
 ) {
     companion object {
         const val ID = "id"
@@ -17,5 +18,6 @@ data class UserModel(
         const val PHONE_NUMBER = "phoneNumber"
         const val PHOTO_URL = "photoUrl"
         const val LIKES = "likes"
+        const val ADJECTIVES = "adjectives"
     }
 }

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/data/model/UserDetailsDTO.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/data/model/UserDetailsDTO.kt
@@ -11,14 +11,16 @@ internal data class UserDetailsDTO(
     @SerialName("name") val name: String = EMPTY_STRING,
     @SerialName("phoneNumber") val phoneNumber: String = EMPTY_STRING,
     @SerialName("photoUrl") val photoUrl: String? = null,
-    @SerialName("likes") val likes: List<String> = emptyList()
+    @SerialName("likes") val likes: List<String> = emptyList(),
+    @SerialName("adjectives") val adjectives: Map<String, List<String>> = emptyMap()
 ) {
     fun toDomain() = UserModel(
         id = id,
         name = name,
         phoneNumber = phoneNumber,
         photoUrl = photoUrl,
-        likes = likes
+        likes = likes,
+        adjectives = adjectives
     )
 
     companion object {
@@ -27,7 +29,8 @@ internal data class UserDetailsDTO(
             name = model.name,
             phoneNumber = model.phoneNumber,
             photoUrl = model.photoUrl,
-            likes = model.likes
+            likes = model.likes,
+            adjectives = model.adjectives
         )
     }
 }

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/domain/useCases/AddMemberAdjectiveUseCase.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/domain/useCases/AddMemberAdjectiveUseCase.kt
@@ -1,0 +1,39 @@
+package br.com.brunocarvalhs.group.details.app.domain.useCases
+
+import br.com.brunocarvalhs.core.domain.model.GroupModel
+import br.com.brunocarvalhs.deviceid.DeviceService
+import br.com.brunocarvalhs.group.details.app.domain.repository.GroupDetailsRepository
+import javax.inject.Inject
+
+internal class AddMemberAdjectiveUseCase @Inject constructor(
+    private val repository: GroupDetailsRepository,
+    private val deviceService: DeviceService,
+) {
+    suspend operator fun invoke(
+        group: GroupModel,
+        memberId: String,
+        adjective: String
+    ): Result<GroupModel> = runCatching {
+        val deviceId = deviceService.getDeviceId()
+        val sanitizedAdjective = adjective.trim()
+        require(sanitizedAdjective.isNotBlank()) { "Adjective must not be blank" }
+
+        val updatedMembers = group.members.map { member ->
+            if (member.id == memberId || member.phoneNumber == memberId) {
+                val contributions = member.adjectives[deviceId].orEmpty()
+                if (contributions.any { it.equals(sanitizedAdjective, ignoreCase = true) }) {
+                    member
+                } else {
+                    member.copy(
+                        adjectives = member.adjectives +
+                            (deviceId to contributions + sanitizedAdjective)
+                    )
+                }
+            } else {
+                member
+            }
+        }
+
+        repository.update(group.copy(members = updatedMembers))
+    }
+}

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsIntent.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsIntent.kt
@@ -11,4 +11,5 @@ internal sealed interface GroupDetailsIntent {
     data class ToggleReminder(val enabled: Boolean) : GroupDetailsIntent
     data class RemoveMember(val memberId: String) : GroupDetailsIntent
     data class UpdateLikes(val likes: List<String>) : GroupDetailsIntent
+    data class AddAdjective(val memberId: String, val adjective: String) : GroupDetailsIntent
 }

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsScreen.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsScreen.kt
@@ -69,6 +69,7 @@ import br.com.brunocarvalhs.core.domain.model.GroupModel
 import br.com.brunocarvalhs.core.domain.model.UserModel
 import br.com.brunocarvalhs.group.details.R
 import br.com.brunocarvalhs.group.details.app.presentation.components.ActionIconCard
+import br.com.brunocarvalhs.group.details.app.presentation.components.AddAdjectiveDialog
 import br.com.brunocarvalhs.group.details.app.presentation.components.EditLikesDialog
 import br.com.brunocarvalhs.group.details.app.presentation.components.MemberItem
 import br.com.brunocarvalhs.group.details.app.presentation.components.SectionHeader
@@ -93,6 +94,7 @@ internal fun GroupDetailsScreen(
     val group = uiState.group
     var memberPendingRemoval by remember { mutableStateOf<UserModel?>(null) }
     var editingLikesMember by remember { mutableStateOf<UserModel?>(null) }
+    var addingAdjectiveMember by remember { mutableStateOf<UserModel?>(null) }
 
     val notificationPermissionState = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         rememberPermissionState(Manifest.permission.POST_NOTIFICATIONS)
@@ -150,7 +152,8 @@ internal fun GroupDetailsScreen(
         },
         onRemoveMember = { member -> memberPendingRemoval = member },
         onShareWishlist = { viewModel.handleIntent(GroupDetailsIntent.ShareWishlist) },
-        onEditLikes = { member -> editingLikesMember = member }
+        onEditLikes = { member -> editingLikesMember = member },
+        onAddAdjective = { member -> addingAdjectiveMember = member }
     )
 
     memberPendingRemoval?.let { member ->
@@ -188,6 +191,17 @@ internal fun GroupDetailsScreen(
             }
         )
     }
+
+    addingAdjectiveMember?.let { member ->
+        AddAdjectiveDialog(
+            participant = member.name,
+            onDismiss = { addingAdjectiveMember = null },
+            onSave = { adjective ->
+                viewModel.handleIntent(GroupDetailsIntent.AddAdjective(member.id, adjective))
+                addingAdjectiveMember = null
+            }
+        )
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -221,6 +235,7 @@ private fun GroupDetailsContent(
     onShareWishlist: () -> Unit = {},
     currentDeviceId: String = "",
     onEditLikes: (UserModel) -> Unit = {},
+    onAddAdjective: (UserModel) -> Unit = {},
 ) {
     Scaffold(
         topBar = {
@@ -292,6 +307,7 @@ private fun GroupDetailsContent(
                 MemberItem(
                     participant = member.name,
                     likes = member.likes,
+                    adjectives = member.adjectives.values.flatten().distinct(),
                     isAdministrator = isOwner,
                     onRemove = if (isOwner && !isDrawn) {
                         { onRemoveMember(member) }
@@ -302,6 +318,11 @@ private fun GroupDetailsContent(
                         { onEditLikes(member) }
                     } else {
                         null
+                    },
+                    onAddAdjective = if (isCurrentUser) {
+                        null
+                    } else {
+                        { onAddAdjective(member) }
                     },
                 )
             }

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsViewModel.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsViewModel.kt
@@ -10,6 +10,7 @@ import br.com.brunocarvalhs.core.analytics.AnalyticsService
 import br.com.brunocarvalhs.core.analytics.commons.AnalyticsEvent
 import br.com.brunocarvalhs.core.navigation.routers.GroupDetailsGraph
 import br.com.brunocarvalhs.deviceid.DeviceService
+import br.com.brunocarvalhs.group.details.app.domain.useCases.AddMemberAdjectiveUseCase
 import br.com.brunocarvalhs.group.details.app.domain.useCases.GroupDeleteUseCase
 import br.com.brunocarvalhs.group.details.app.domain.useCases.GroupExitUseCase
 import br.com.brunocarvalhs.group.details.app.domain.useCases.GroupReadUseCase
@@ -47,6 +48,7 @@ internal class GroupDetailsViewModel @Inject constructor(
     private val removeMemberUseCase: RemoveMemberUseCase,
     private val shareWishlistUseCase: ShareWishlistUseCase,
     private val updateMemberLikesUseCase: UpdateMemberLikesUseCase,
+    private val addMemberAdjectiveUseCase: AddMemberAdjectiveUseCase,
     private val deviceService: DeviceService,
     private val analyticsService: AnalyticsService
 ) : ViewModel() {
@@ -71,6 +73,7 @@ internal class GroupDetailsViewModel @Inject constructor(
         is GroupDetailsIntent.RemoveMember -> removeMember(intent.memberId)
         GroupDetailsIntent.ShareWishlist -> shareWishlist()
         is GroupDetailsIntent.UpdateLikes -> updateLikes(intent.likes)
+        is GroupDetailsIntent.AddAdjective -> addAdjective(intent.memberId, intent.adjective)
     }
 
     private fun loadReminderState() {
@@ -123,6 +126,26 @@ internal class GroupDetailsViewModel @Inject constructor(
                 .onFailure { error ->
                     Timber.e(error, "Error updating member likes")
                     _uiState.update { it.copy(isLoading = false, error = "Erro ao salvar interesses") }
+                }
+        }
+    }
+
+    @AddTrace(name = "GroupDetailsViewModel.addAdjective", enabled = true)
+    private fun addAdjective(memberId: String, adjective: String) {
+        analyticsService.logEvent(
+            name = AnalyticsEvent.SUBMIT,
+            params = mapOf(
+                AnalyticsParam.ACTION to "add_member_adjective"
+            )
+        )
+        viewModelScope.launch {
+            addMemberAdjectiveUseCase(_uiState.value.group, memberId, adjective)
+                .onSuccess { group ->
+                    _uiState.update { it.copy(group = group) }
+                }
+                .onFailure { error ->
+                    Timber.e(error, "Error adding member adjective")
+                    _uiState.update { it.copy(error = "Erro ao adicionar adjetivo") }
                 }
         }
     }

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/components/AddAdjectiveDialog.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/components/AddAdjectiveDialog.kt
@@ -1,0 +1,57 @@
+package br.com.brunocarvalhs.group.details.app.presentation.components
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import br.com.brunocarvalhs.group.details.R
+
+@Composable
+internal fun AddAdjectiveDialog(
+    participant: String,
+    onDismiss: () -> Unit,
+    onSave: (String) -> Unit,
+) {
+    var input by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.add_adjective_title, participant)) },
+        text = {
+            OutlinedTextField(
+                value = input,
+                onValueChange = { input = it },
+                modifier = Modifier,
+                placeholder = { Text(stringResource(R.string.add_adjective_hint)) },
+                singleLine = true,
+                supportingText = {
+                    Text(
+                        text = stringResource(R.string.add_adjective_description),
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+            )
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onSave(input) },
+                enabled = input.isNotBlank()
+            ) {
+                Text(stringResource(R.string.add_adjective_save_action))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.add_adjective_cancel_action))
+            }
+        }
+    )
+}

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/components/ContactItem.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/components/ContactItem.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -48,6 +49,7 @@ internal fun ContactItem(
     subtitle: String? = null,
     photoUrl: String? = null,
     likes: List<String> = emptyList(),
+    adjectives: List<String> = emptyList(),
     isSelected: Boolean = false,
     isLikedExpanded: Boolean = false,
     paddingValues: PaddingValues = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
@@ -157,6 +159,26 @@ internal fun ContactItem(
                         hashMapOf(GroupModel.NAME to name, GroupModel.PHOTO to photoUrl),
                         isLiked
                     )
+                }
+            }
+
+            if (adjectives.isNotEmpty()) {
+                LazyRow(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 16.dp, bottom = 12.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(adjectives) { adjective ->
+                        AssistChip(
+                            onClick = {},
+                            label = { Text(adjective) },
+                            colors = AssistChipDefaults.assistChipColors(
+                                containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                                labelColor = MaterialTheme.colorScheme.onTertiaryContainer
+                            )
+                        )
+                    }
                 }
             }
 

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/components/MemberItem.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/components/MemberItem.kt
@@ -1,6 +1,7 @@
 package br.com.brunocarvalhs.group.details.app.presentation.components
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AddReaction
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.sharp.KeyboardArrowDown
@@ -16,15 +17,18 @@ import br.com.brunocarvalhs.group.details.R
 internal fun MemberItem(
     participant: String = "",
     likes: List<String> = emptyList(),
+    adjectives: List<String> = emptyList(),
     isAdministrator: Boolean = false,
     onEdit: (() -> Unit)? = null,
     onRemove: (() -> Unit)? = null,
+    onAddAdjective: (() -> Unit)? = null,
 ) {
     val hasLikes = likes.any { it.isNotBlank() }
 
     ContactItem(
         name = participant,
         likes = likes,
+        adjectives = adjectives,
         action = { _, isLiked ->
 
             if (hasLikes) {
@@ -34,6 +38,18 @@ internal fun MemberItem(
                         if (isLiked) R.string.collapse_likes_action else R.string.expand_likes_action
                     )
                 )
+            }
+
+            onAddAdjective?.let {
+                IconButton(onClick = it) {
+                    Icon(
+                        imageVector = Icons.Filled.AddReaction,
+                        contentDescription = stringResource(
+                            R.string.add_adjective_action,
+                            participant
+                        )
+                    )
+                }
             }
 
             onEdit?.let {

--- a/features/group/details/src/main/res/values-de/strings.xml
+++ b/features/group/details/src/main/res/values-de/strings.xml
@@ -52,4 +52,10 @@
     <string name="edit_likes_cancel_action">Abbrechen</string>
     <string name="edit_likes_remove_action">%1$s entfernen</string>
     <string name="edit_likes_empty_state">Noch keine Interessen hinzugefügt</string>
+    <string name="add_adjective_action">Ein Adjektiv für %1$s hinzufügen</string>
+    <string name="add_adjective_title">Beschreibe %1$s mit einem Wort</string>
+    <string name="add_adjective_hint">z. B. Lustig, Nett…</string>
+    <string name="add_adjective_description">Jeder in der Gruppe kann Adjektive hinzufügen – sie erscheinen auf der Karte dieses Mitglieds.</string>
+    <string name="add_adjective_save_action">Hinzufügen</string>
+    <string name="add_adjective_cancel_action">Abbrechen</string>
 </resources>

--- a/features/group/details/src/main/res/values-es/strings.xml
+++ b/features/group/details/src/main/res/values-es/strings.xml
@@ -52,4 +52,10 @@
     <string name="edit_likes_cancel_action">Cancelar</string>
     <string name="edit_likes_remove_action">Eliminar %1$s</string>
     <string name="edit_likes_empty_state">Aún no se agregaron intereses</string>
+    <string name="add_adjective_action">Añadir un adjetivo para %1$s</string>
+    <string name="add_adjective_title">Describe a %1$s en una palabra</string>
+    <string name="add_adjective_hint">Ej: Divertido, Amable…</string>
+    <string name="add_adjective_description">Cualquiera en el grupo puede añadir adjetivos: aparecerán en la tarjeta de este miembro.</string>
+    <string name="add_adjective_save_action">Añadir</string>
+    <string name="add_adjective_cancel_action">Cancelar</string>
 </resources>

--- a/features/group/details/src/main/res/values-fr/strings.xml
+++ b/features/group/details/src/main/res/values-fr/strings.xml
@@ -52,4 +52,10 @@
     <string name="edit_likes_cancel_action">Annuler</string>
     <string name="edit_likes_remove_action">Supprimer %1$s</string>
     <string name="edit_likes_empty_state">Aucun centre d\'intérêt ajouté pour le moment</string>
+    <string name="add_adjective_action">Ajouter un adjectif pour %1$s</string>
+    <string name="add_adjective_title">Décrivez %1$s en un mot</string>
+    <string name="add_adjective_hint">Ex : Drôle, Gentil…</string>
+    <string name="add_adjective_description">Tout le monde dans le groupe peut ajouter des adjectifs — ils apparaîtront sur la fiche de ce membre.</string>
+    <string name="add_adjective_save_action">Ajouter</string>
+    <string name="add_adjective_cancel_action">Annuler</string>
 </resources>

--- a/features/group/details/src/main/res/values-ko/strings.xml
+++ b/features/group/details/src/main/res/values-ko/strings.xml
@@ -52,4 +52,10 @@
     <string name="edit_likes_cancel_action">취소</string>
     <string name="edit_likes_remove_action">%1$s 삭제</string>
     <string name="edit_likes_empty_state">아직 추가된 관심사가 없습니다</string>
+    <string name="add_adjective_action">%1$s에 대한 형용사 추가</string>
+    <string name="add_adjective_title">%1$s를 한 단어로 표현해보세요</string>
+    <string name="add_adjective_hint">예: 재미있는, 친절한…</string>
+    <string name="add_adjective_description">그룹의 누구나 형용사를 추가할 수 있어요 — 이 멤버의 카드에 표시됩니다.</string>
+    <string name="add_adjective_save_action">추가</string>
+    <string name="add_adjective_cancel_action">취소</string>
 </resources>

--- a/features/group/details/src/main/res/values-nl/strings.xml
+++ b/features/group/details/src/main/res/values-nl/strings.xml
@@ -52,4 +52,10 @@
     <string name="edit_likes_cancel_action">Annuleren</string>
     <string name="edit_likes_remove_action">%1$s verwijderen</string>
     <string name="edit_likes_empty_state">Nog geen interesses toegevoegd</string>
+    <string name="add_adjective_action">Een bijvoeglijk naamwoord toevoegen voor %1$s</string>
+    <string name="add_adjective_title">Beschrijf %1$s in één woord</string>
+    <string name="add_adjective_hint">Bijv. Grappig, Aardig…</string>
+    <string name="add_adjective_description">Iedereen in de groep kan bijvoeglijke naamwoorden toevoegen — ze verschijnen op de kaart van dit lid.</string>
+    <string name="add_adjective_save_action">Toevoegen</string>
+    <string name="add_adjective_cancel_action">Annuleren</string>
 </resources>

--- a/features/group/details/src/main/res/values-pl/strings.xml
+++ b/features/group/details/src/main/res/values-pl/strings.xml
@@ -52,4 +52,10 @@
     <string name="edit_likes_cancel_action">Anuluj</string>
     <string name="edit_likes_remove_action">Usuń %1$s</string>
     <string name="edit_likes_empty_state">Nie dodano jeszcze żadnych zainteresowań</string>
+    <string name="add_adjective_action">Dodaj przymiotnik dla %1$s</string>
+    <string name="add_adjective_title">Opisz %1$s jednym słowem</string>
+    <string name="add_adjective_hint">Np. Zabawny, Miły…</string>
+    <string name="add_adjective_description">Każdy w grupie może dodawać przymiotniki — pojawią się na karcie tego uczestnika.</string>
+    <string name="add_adjective_save_action">Dodaj</string>
+    <string name="add_adjective_cancel_action">Anuluj</string>
 </resources>

--- a/features/group/details/src/main/res/values-pt-rBR/strings.xml
+++ b/features/group/details/src/main/res/values-pt-rBR/strings.xml
@@ -52,4 +52,10 @@
     <string name="edit_likes_cancel_action">Cancelar</string>
     <string name="edit_likes_remove_action">Remover %1$s</string>
     <string name="edit_likes_empty_state">Nenhum interesse adicionado ainda</string>
+    <string name="add_adjective_action">Adicionar um adjetivo para %1$s</string>
+    <string name="add_adjective_title">Descreva %1$s em uma palavra</string>
+    <string name="add_adjective_hint">Ex: Engraçado, Gentil…</string>
+    <string name="add_adjective_description">Qualquer pessoa do grupo pode adicionar adjetivos — eles aparecem no cartão desse membro.</string>
+    <string name="add_adjective_save_action">Adicionar</string>
+    <string name="add_adjective_cancel_action">Cancelar</string>
 </resources>

--- a/features/group/details/src/main/res/values/strings.xml
+++ b/features/group/details/src/main/res/values/strings.xml
@@ -52,4 +52,10 @@
     <string name="edit_likes_cancel_action">Cancel</string>
     <string name="edit_likes_remove_action">Remove %1$s</string>
     <string name="edit_likes_empty_state">No interests added yet</string>
+    <string name="add_adjective_action">Add an adjective for %1$s</string>
+    <string name="add_adjective_title">Describe %1$s in one word</string>
+    <string name="add_adjective_hint">E.g. Funny, Kind…</string>
+    <string name="add_adjective_description">Anyone in the group can add adjectives — they\'ll show up on this member\'s card.</string>
+    <string name="add_adjective_save_action">Add</string>
+    <string name="add_adjective_cancel_action">Cancel</string>
 </resources>

--- a/features/group/details/src/test/java/br/com/brunocarvalhs/group/details/app/domain/useCases/AddMemberAdjectiveUseCaseTest.kt
+++ b/features/group/details/src/test/java/br/com/brunocarvalhs/group/details/app/domain/useCases/AddMemberAdjectiveUseCaseTest.kt
@@ -1,0 +1,106 @@
+package br.com.brunocarvalhs.group.details.app.domain.useCases
+
+import br.com.brunocarvalhs.core.domain.model.GroupModel
+import br.com.brunocarvalhs.core.domain.model.UserModel
+import br.com.brunocarvalhs.deviceid.DeviceService
+import br.com.brunocarvalhs.group.details.app.domain.repository.GroupDetailsRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class AddMemberAdjectiveUseCaseTest {
+
+    private val repository: GroupDetailsRepository = mockk()
+    private val deviceService: DeviceService = mockk()
+    private lateinit var useCase: AddMemberAdjectiveUseCase
+
+    @Before
+    fun setup() {
+        useCase = AddMemberAdjectiveUseCase(repository, deviceService)
+    }
+
+    @Test
+    fun `invoke should add an adjective from the current device to the target member`() = runTest {
+        // Given
+        val target = UserModel(id = "device-2", name = "Isabella")
+        val group = GroupModel(id = "group-1", members = listOf(target))
+
+        coEvery { deviceService.getDeviceId() } returns "device-1"
+        coEvery { repository.update(any()) } answers { firstArg() }
+
+        // When
+        val result = useCase(group, "device-2", " Engraçada ")
+
+        // Then
+        assertTrue(result.isSuccess)
+        val updatedMember = result.getOrThrow().members.first()
+        assertEquals(listOf("Engraçada"), updatedMember.adjectives["device-1"])
+        coVerify { repository.update(any()) }
+    }
+
+    @Test
+    fun `invoke should keep contributions from other devices and append to the same contributor`() =
+        runTest {
+            // Given
+            val target = UserModel(
+                id = "device-2",
+                name = "Isabella",
+                adjectives = mapOf("device-1" to listOf("Gentil"), "device-3" to listOf("Divertida"))
+            )
+            val group = GroupModel(id = "group-1", members = listOf(target))
+
+            coEvery { deviceService.getDeviceId() } returns "device-1"
+            coEvery { repository.update(any()) } answers { firstArg() }
+
+            // When
+            val result = useCase(group, "device-2", "Criativa")
+
+            // Then
+            assertTrue(result.isSuccess)
+            val updatedMember = result.getOrThrow().members.first()
+            assertEquals(listOf("Gentil", "Criativa"), updatedMember.adjectives["device-1"])
+            assertEquals(listOf("Divertida"), updatedMember.adjectives["device-3"])
+        }
+
+    @Test
+    fun `invoke should not duplicate the same adjective from the same contributor`() = runTest {
+        // Given
+        val target = UserModel(
+            id = "device-2",
+            name = "Isabella",
+            adjectives = mapOf("device-1" to listOf("Gentil"))
+        )
+        val group = GroupModel(id = "group-1", members = listOf(target))
+
+        coEvery { deviceService.getDeviceId() } returns "device-1"
+        coEvery { repository.update(any()) } answers { firstArg() }
+
+        // When
+        val result = useCase(group, "device-2", "gentil")
+
+        // Then
+        assertTrue(result.isSuccess)
+        assertEquals(listOf("Gentil"), result.getOrThrow().members.first().adjectives["device-1"])
+    }
+
+    @Test
+    fun `invoke should fail when the adjective is blank`() = runTest {
+        // Given
+        val target = UserModel(id = "device-2", name = "Isabella")
+        val group = GroupModel(id = "group-1", members = listOf(target))
+
+        coEvery { deviceService.getDeviceId() } returns "device-1"
+
+        // When
+        val result = useCase(group, "device-2", "   ")
+
+        // Then
+        assertTrue(result.isFailure)
+        coVerify(inverse = true) { repository.update(any()) }
+    }
+}


### PR DESCRIPTION
## Summary
- Adiciona uma feature leve de "adjetivos" por membro: qualquer participante pode adicionar um adjetivo curto (ex: "Engraçado", "Gentil") descrevendo outro membro do grupo.
- As contribuições se acumulam e aparecem como chips no card do membro, no mesmo estilo dos "likes" já existentes.
- `UserModel`/`UserDetailsDTO` ganham um campo `adjectives: Map<contributorDeviceId, List<String>>`, seguindo o mesmo formato de documento Firestore com membros embutidos.
- `AddMemberAdjectiveUseCase` segue o mesmo padrão read-modify-write do `UpdateMemberLikesUseCase`, com deduplicação case-insensitive por contribuinte.
- O botão de adicionar adjetivo fica escondido na própria linha do usuário atual (a ideia é receber de outros, não de si mesmo).

## Test plan
- [x] `./gradlew :features:group:details:compileDebugKotlin` — compila sem erros
- [x] `./gradlew :features:group:details:testDebugUnitTest --tests AddMemberAdjectiveUseCaseTest` — 4 testes novos, todos passando
- [x] `./gradlew :features:group:details:lintDebug` — sem erros (traduzido para as 8 línguas suportadas)
- [ ] Teste manual: abrir detalhes de um grupo, tocar no botão de adjetivo em outro membro, adicionar uma palavra e confirmar que aparece no card dele

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDd6WxKNjnPHjvPpiqyYN2