### PR TITLE
feat(chat): add AI gift-suggestion chat using Firebase AI Logic

### DIFF
--- a/core/navigation/src/main/java/br/com/brunocarvalhs/core/navigation/CommonNavigator.kt
+++ b/core/navigation/src/main/java/br/com/brunocarvalhs/core/navigation/CommonNavigator.kt
@@ -11,6 +11,7 @@ interface CommonNavigator {
     fun navigateToGroupList(navController: NavHostController, popUpTo: KClass<*>? = null, inclusive: Boolean = false)
     fun navigateToDraw(navController: NavHostController, group: GroupModel)
     fun navigateToChat(navController: NavHostController, group: GroupModel)
+    fun navigateToAiGiftChat(navController: NavHostController, group: GroupModel)
     fun navigateToEditGroup(navController: NavHostController, group: GroupModel)
     fun navigateToContacts(navController: NavHostController, group: GroupModel)
 }

--- a/core/navigation/src/main/java/br/com/brunocarvalhs/core/navigation/navigation/AppNavigator.kt
+++ b/core/navigation/src/main/java/br/com/brunocarvalhs/core/navigation/navigation/AppNavigator.kt
@@ -1,6 +1,7 @@
 package br.com.brunocarvalhs.core.navigation.navigation
 
 import androidx.navigation.NavHostController
+import br.com.brunocarvalhs.core.navigation.routers.AiGiftChatGraph
 import br.com.brunocarvalhs.core.navigation.routers.ChatGraph
 import br.com.brunocarvalhs.core.navigation.CommonNavigator
 import br.com.brunocarvalhs.core.navigation.routers.ContactsRouter
@@ -51,6 +52,12 @@ class AppNavigator @Inject constructor() : CommonNavigator {
 
     override fun navigateToChat(navController: NavHostController, group: GroupModel) {
         navController.navigate(ChatGraph(group)) {
+            launchSingleTop = true
+        }
+    }
+
+    override fun navigateToAiGiftChat(navController: NavHostController, group: GroupModel) {
+        navController.navigate(AiGiftChatGraph(group)) {
             launchSingleTop = true
         }
     }

--- a/core/navigation/src/main/java/br/com/brunocarvalhs/core/navigation/routers/Routers.kt
+++ b/core/navigation/src/main/java/br/com/brunocarvalhs/core/navigation/routers/Routers.kt
@@ -53,6 +53,17 @@ data class ChatGraph(
 }
 
 @Serializable
+data class AiGiftChatGraph(
+    val group: GroupModel,
+) {
+    companion object {
+        val typeMap = mapOf(
+            typeOf<GroupModel>() to navTypeSerializer<GroupModel>()
+        )
+    }
+}
+
+@Serializable
 data class DrawGraph(val group: GroupModel) {
     companion object {
         val typeMap = mapOf(

--- a/features/chat/build.gradle.kts
+++ b/features/chat/build.gradle.kts
@@ -122,4 +122,7 @@ dependencies {
 
     // Firebase Realtime Database
     implementation(libs.firebase.database)
+
+    // Firebase AI Logic (Gemini)
+    implementation(libs.firebase.ai)
 }

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/AiGiftChatInitializer.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/AiGiftChatInitializer.kt
@@ -1,0 +1,46 @@
+package br.com.brunocarvalhs.chat
+
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import androidx.navigation.navigation
+import br.com.brunocarvalhs.chat.app.presentation.AiGiftChatScreen
+import br.com.brunocarvalhs.chat.app.presentation.AiGiftChatViewModel
+import br.com.brunocarvalhs.chat.commons.navigation.AiGiftChatRouter
+import br.com.brunocarvalhs.core.navigation.routers.AiGiftChatGraph
+import kotlin.properties.Delegates
+
+class AiGiftChatInitializer(private val builder: Builder) {
+
+    fun build(navGraphBuilder: NavGraphBuilder) {
+        return navGraphBuilder.navigation<AiGiftChatGraph>(
+            startDestination = AiGiftChatRouter,
+            typeMap = AiGiftChatGraph.typeMap,
+        ) {
+            composable<AiGiftChatRouter> {
+                val viewModel = hiltViewModel<AiGiftChatViewModel>()
+                AiGiftChatScreen(
+                    viewModel = viewModel,
+                    onBack = builder.onBack
+                )
+            }
+        }
+    }
+
+    class Builder {
+        internal var navController: NavHostController by Delegates.notNull()
+        internal var onBack: () -> Unit = {}
+
+        fun navController(navController: NavHostController) = apply {
+            this.navController = navController
+        }
+
+        fun onBack(onBack: () -> Unit) = apply {
+            this.onBack = onBack
+        }
+
+        fun build(navGraphBuilder: NavGraphBuilder): AiGiftChatInitializer =
+            AiGiftChatInitializer(this).also { it.build(navGraphBuilder) }
+    }
+}

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/AiGiftChatInitializerImpl.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/AiGiftChatInitializerImpl.kt
@@ -1,0 +1,16 @@
+package br.com.brunocarvalhs.chat
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import br.com.brunocarvalhs.core.navigation.FeatureInitializer
+import javax.inject.Inject
+
+class AiGiftChatInitializerImpl @Inject constructor() : FeatureInitializer {
+
+    override fun register(navGraphBuilder: NavGraphBuilder, navController: NavHostController) {
+        AiGiftChatInitializer.Builder()
+            .navController(navController)
+            .onBack { navController.popBackStack() }
+            .build(navGraphBuilder)
+    }
+}

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/data/model/AiChatMessage.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/data/model/AiChatMessage.kt
@@ -1,0 +1,7 @@
+package br.com.brunocarvalhs.chat.app.data.model
+
+data class AiChatMessage(
+    val text: String,
+    val isFromUser: Boolean,
+    val timestamp: Long = System.currentTimeMillis()
+)

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/data/services/FirebaseAiGiftAssistantService.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/data/services/FirebaseAiGiftAssistantService.kt
@@ -1,0 +1,41 @@
+package br.com.brunocarvalhs.chat.app.data.services
+
+import br.com.brunocarvalhs.chat.app.domain.services.AiChatSession
+import br.com.brunocarvalhs.chat.app.domain.services.AiGiftAssistantService
+import com.google.firebase.Firebase
+import com.google.firebase.ai.ai
+import com.google.firebase.ai.type.GenerativeBackend
+import com.google.firebase.ai.type.content
+import javax.inject.Inject
+
+class FirebaseAiGiftAssistantService @Inject constructor() : AiGiftAssistantService {
+
+    override fun startChat(groupName: String): AiChatSession {
+        val model = Firebase.ai(backend = GenerativeBackend.googleAI()).generativeModel(
+            modelName = MODEL_NAME,
+            systemInstruction = content {
+                text(
+                    "You are a friendly, creative gift-idea assistant inside the Friends Secrets " +
+                        "Secret Santa app. The user wants gift ideas for someone in their group " +
+                        "\"$groupName\". Ask brief clarifying questions when helpful (hobbies, " +
+                        "interests, budget, age) and suggest specific, actionable, varied gift " +
+                        "ideas. Keep answers concise and always reply in the same language the " +
+                        "user writes in."
+                )
+            }
+        )
+        return FirebaseAiChatSession(model.startChat())
+    }
+
+    private companion object {
+        const val MODEL_NAME = "gemini-2.5-flash"
+    }
+}
+
+private class FirebaseAiChatSession(
+    private val chat: com.google.firebase.ai.Chat
+) : AiChatSession {
+    override suspend fun sendMessage(text: String): Result<String> = runCatching {
+        chat.sendMessage(text).text.orEmpty()
+    }
+}

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/domain/services/AiGiftAssistantService.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/domain/services/AiGiftAssistantService.kt
@@ -1,0 +1,9 @@
+package br.com.brunocarvalhs.chat.app.domain.services
+
+interface AiGiftAssistantService {
+    fun startChat(groupName: String): AiChatSession
+}
+
+interface AiChatSession {
+    suspend fun sendMessage(text: String): Result<String>
+}

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/domain/usecase/StartAiGiftChatUseCase.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/domain/usecase/StartAiGiftChatUseCase.kt
@@ -1,0 +1,11 @@
+package br.com.brunocarvalhs.chat.app.domain.usecase
+
+import br.com.brunocarvalhs.chat.app.domain.services.AiChatSession
+import br.com.brunocarvalhs.chat.app.domain.services.AiGiftAssistantService
+import javax.inject.Inject
+
+class StartAiGiftChatUseCase @Inject constructor(
+    private val service: AiGiftAssistantService
+) {
+    operator fun invoke(groupName: String): AiChatSession = service.startChat(groupName)
+}

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/AiGiftChatIntent.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/AiGiftChatIntent.kt
@@ -1,0 +1,6 @@
+package br.com.brunocarvalhs.chat.app.presentation
+
+internal sealed interface AiGiftChatIntent {
+    data class UpdateInput(val text: String) : AiGiftChatIntent
+    data object SendMessage : AiGiftChatIntent
+}

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/AiGiftChatScreen.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/AiGiftChatScreen.kt
@@ -112,7 +112,7 @@ internal fun AiGiftChatScreen(
 }
 
 @Composable
-private fun AiChatMessageItem(message: AiChatMessage) {
+private fun AiChatMessageItem(message: AiChatMessage, modifier: Modifier = Modifier) {
     val alignment = if (message.isFromUser) Alignment.CenterEnd else Alignment.CenterStart
     val containerColor = if (message.isFromUser) {
         MaterialTheme.colorScheme.primaryContainer
@@ -126,7 +126,7 @@ private fun AiChatMessageItem(message: AiChatMessage) {
     }
 
     Box(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .padding(vertical = 4.dp),
         contentAlignment = alignment
@@ -161,8 +161,8 @@ private fun AiChatMessageItem(message: AiChatMessage) {
 }
 
 @Composable
-private fun AiTypingIndicator() {
-    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterStart) {
+private fun AiTypingIndicator(modifier: Modifier = Modifier) {
+    Box(modifier = modifier.fillMaxWidth(), contentAlignment = Alignment.CenterStart) {
         Card(
             colors = CardDefaults.cardColors(
                 containerColor = MaterialTheme.colorScheme.secondaryContainer

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/AiGiftChatScreen.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/AiGiftChatScreen.kt
@@ -1,0 +1,236 @@
+package br.com.brunocarvalhs.chat.app.presentation
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.unit.dp
+import br.com.brunocarvalhs.chat.R
+import br.com.brunocarvalhs.chat.app.data.model.AiChatMessage
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun AiGiftChatScreen(
+    viewModel: AiGiftChatViewModel,
+    onBack: () -> Unit
+) {
+    val state by viewModel.uiState.collectAsState()
+    val listState = rememberLazyListState()
+
+    LaunchedEffect(state.messages.size, state.isLoading) {
+        if (state.messages.isNotEmpty()) {
+            listState.animateScrollToItem(state.messages.size - 1)
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.ai_gift_chat_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back)
+                        )
+                    }
+                }
+            )
+        },
+        bottomBar = {
+            AiGiftChatInputBar(
+                text = state.inputText,
+                enabled = !state.isLoading,
+                onTextChange = { viewModel.handleIntent(AiGiftChatIntent.UpdateInput(it)) },
+                onSend = { viewModel.handleIntent(AiGiftChatIntent.SendMessage) }
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            LazyColumn(
+                state = listState,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth(),
+                contentPadding = PaddingValues(16.dp)
+            ) {
+                items(state.messages, key = { it.timestamp }) { message ->
+                    AiChatMessageItem(message = message)
+                }
+                if (state.isLoading) {
+                    item(key = "loading") {
+                        AiTypingIndicator()
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AiChatMessageItem(message: AiChatMessage) {
+    val alignment = if (message.isFromUser) Alignment.CenterEnd else Alignment.CenterStart
+    val containerColor = if (message.isFromUser) {
+        MaterialTheme.colorScheme.primaryContainer
+    } else {
+        MaterialTheme.colorScheme.secondaryContainer
+    }
+    val shape = if (message.isFromUser) {
+        RoundedCornerShape(16.dp, 16.dp, 0.dp, 16.dp)
+    } else {
+        RoundedCornerShape(16.dp, 16.dp, 16.dp, 0.dp)
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        contentAlignment = alignment
+    ) {
+        Card(
+            shape = shape,
+            colors = CardDefaults.cardColors(containerColor = containerColor),
+            modifier = Modifier.widthIn(max = 280.dp)
+        ) {
+            Column(modifier = Modifier.padding(12.dp)) {
+                if (!message.isFromUser) {
+                    Row {
+                        Icon(
+                            imageVector = Icons.Default.AutoAwesome,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp),
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                        Spacer(modifier = Modifier.size(4.dp))
+                        Text(
+                            text = stringResource(R.string.ai_gift_chat_assistant_name),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                    Spacer(modifier = Modifier.size(4.dp))
+                }
+                Text(text = message.text, style = MaterialTheme.typography.bodyLarge)
+            }
+        }
+    }
+}
+
+@Composable
+private fun AiTypingIndicator() {
+    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterStart) {
+        Card(
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.secondaryContainer
+            ),
+            shape = RoundedCornerShape(16.dp, 16.dp, 16.dp, 0.dp)
+        ) {
+            Row(
+                modifier = Modifier.padding(16.dp, 12.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                CircularProgressIndicator(modifier = Modifier.size(14.dp), strokeWidth = 2.dp)
+                Spacer(modifier = Modifier.size(8.dp))
+                Text(
+                    text = stringResource(R.string.ai_gift_chat_typing),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AiGiftChatInputBar(
+    text: String,
+    enabled: Boolean,
+    onTextChange: (String) -> Unit,
+    onSend: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        modifier = modifier
+            .navigationBarsPadding()
+            .imePadding(),
+        tonalElevation = 2.dp
+    ) {
+        Row(
+            modifier = Modifier
+                .padding(8.dp)
+                .fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            TextField(
+                value = text,
+                onValueChange = onTextChange,
+                modifier = Modifier.weight(1f),
+                enabled = enabled,
+                placeholder = { Text(text = stringResource(R.string.ai_gift_chat_input)) },
+                maxLines = 4,
+                keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
+                colors = TextFieldDefaults.colors(
+                    focusedIndicatorColor = Color.Transparent,
+                    unfocusedIndicatorColor = Color.Transparent
+                ),
+                shape = RoundedCornerShape(24.dp)
+            )
+            Spacer(modifier = Modifier.size(8.dp))
+            IconButton(
+                onClick = onSend,
+                enabled = enabled && text.isNotBlank(),
+                colors = IconButtonDefaults.iconButtonColors(
+                    contentColor = MaterialTheme.colorScheme.primary
+                )
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.Send,
+                    contentDescription = stringResource(R.string.chat_button_send)
+                )
+            }
+        }
+    }
+}

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/AiGiftChatUiState.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/AiGiftChatUiState.kt
@@ -1,0 +1,11 @@
+package br.com.brunocarvalhs.chat.app.presentation
+
+import br.com.brunocarvalhs.chat.app.data.model.AiChatMessage
+
+internal data class AiGiftChatUiState(
+    val groupName: String = "",
+    val messages: List<AiChatMessage> = emptyList(),
+    val inputText: String = "",
+    val isLoading: Boolean = false,
+    val error: String? = null
+)

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/AiGiftChatViewModel.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/AiGiftChatViewModel.kt
@@ -1,0 +1,98 @@
+package br.com.brunocarvalhs.chat.app.presentation
+
+import AnalyticsParam
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
+import br.com.brunocarvalhs.chat.app.data.model.AiChatMessage
+import br.com.brunocarvalhs.chat.app.domain.services.AiChatSession
+import br.com.brunocarvalhs.chat.app.domain.usecase.StartAiGiftChatUseCase
+import br.com.brunocarvalhs.core.analytics.AnalyticsService
+import br.com.brunocarvalhs.core.analytics.commons.AnalyticsEvent
+import br.com.brunocarvalhs.core.navigation.routers.AiGiftChatGraph
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+
+@HiltViewModel
+internal class AiGiftChatViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    startAiGiftChatUseCase: StartAiGiftChatUseCase,
+    private val analyticsService: AnalyticsService
+) : ViewModel() {
+    private val args = savedStateHandle.toRoute<AiGiftChatGraph>(AiGiftChatGraph.typeMap)
+    private val session: AiChatSession = startAiGiftChatUseCase(args.group.name)
+
+    private val _uiState = MutableStateFlow(
+        AiGiftChatUiState(
+            groupName = args.group.name,
+            messages = listOf(
+                AiChatMessage(
+                    text = INITIAL_GREETING,
+                    isFromUser = false
+                )
+            )
+        )
+    )
+    val uiState: StateFlow<AiGiftChatUiState> = _uiState.asStateFlow()
+
+    init {
+        analyticsService.logEvent(name = AnalyticsEvent.VIEW, params = mapOf(AnalyticsParam.ACTION to "ai_gift_chat_opened"))
+    }
+
+    fun handleIntent(intent: AiGiftChatIntent) {
+        when (intent) {
+            is AiGiftChatIntent.UpdateInput -> _uiState.update { it.copy(inputText = intent.text) }
+            is AiGiftChatIntent.SendMessage -> sendMessage()
+        }
+    }
+
+    private fun sendMessage() {
+        val text = _uiState.value.inputText.trim()
+        if (text.isBlank() || _uiState.value.isLoading) return
+
+        analyticsService.logEvent(
+            name = AnalyticsEvent.SUBMIT,
+            params = mapOf(AnalyticsParam.ACTION to "ai_gift_chat_send_message")
+        )
+
+        _uiState.update {
+            it.copy(
+                messages = it.messages + AiChatMessage(text = text, isFromUser = true),
+                inputText = "",
+                isLoading = true,
+                error = null
+            )
+        }
+
+        viewModelScope.launch {
+            session.sendMessage(text)
+                .onSuccess { reply ->
+                    _uiState.update {
+                        it.copy(
+                            messages = it.messages + AiChatMessage(text = reply, isFromUser = false),
+                            isLoading = false
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    Timber.e(error, "Error sending message to AI gift assistant")
+                    _uiState.update {
+                        it.copy(isLoading = false, error = "Não foi possível falar com a IA agora")
+                    }
+                }
+        }
+    }
+
+    private companion object {
+        const val INITIAL_GREETING =
+            "Oi! 👋 Me conta um pouco sobre a pessoa que você quer presentear: " +
+                "hobbies, gostos, uma faixa de preço... e eu te ajudo com ideias de presente!"
+    }
+}

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/AiGiftChatViewModel.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/AiGiftChatViewModel.kt
@@ -43,7 +43,10 @@ internal class AiGiftChatViewModel @Inject constructor(
     val uiState: StateFlow<AiGiftChatUiState> = _uiState.asStateFlow()
 
     init {
-        analyticsService.logEvent(name = AnalyticsEvent.VIEW, params = mapOf(AnalyticsParam.ACTION to "ai_gift_chat_opened"))
+        analyticsService.logEvent(
+            name = AnalyticsEvent.VIEW,
+            params = mapOf(AnalyticsParam.ACTION to "ai_gift_chat_opened")
+        )
     }
 
     fun handleIntent(intent: AiGiftChatIntent) {

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/commons/di/ChatModule.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/commons/di/ChatModule.kt
@@ -2,12 +2,15 @@ package br.com.brunocarvalhs.chat.commons.di
 
 import android.content.Context
 import androidx.room.Room
+import br.com.brunocarvalhs.chat.AiGiftChatInitializerImpl
 import br.com.brunocarvalhs.chat.ChatInitializerImpl
 import br.com.brunocarvalhs.chat.app.data.local.ChatDatabase
 import br.com.brunocarvalhs.chat.app.data.local.ChatMessageDao
 import br.com.brunocarvalhs.chat.app.data.repository.ChatRepositoryImpl
+import br.com.brunocarvalhs.chat.app.data.services.FirebaseAiGiftAssistantService
 import br.com.brunocarvalhs.chat.app.data.services.FirebaseRealtimeManager
 import br.com.brunocarvalhs.chat.app.domain.repository.ChatRepository
+import br.com.brunocarvalhs.chat.app.domain.services.AiGiftAssistantService
 import br.com.brunocarvalhs.chat.app.domain.services.ChatService
 import br.com.brunocarvalhs.core.navigation.FeatureInitializer
 import com.google.firebase.database.FirebaseDatabase
@@ -31,6 +34,12 @@ abstract class ChatModule {
     ): FeatureInitializer
 
     @Binds
+    @IntoSet
+    abstract fun bindAiGiftChatInitializer(
+        impl: AiGiftChatInitializerImpl
+    ): FeatureInitializer
+
+    @Binds
     abstract fun bindChatService(
         impl: FirebaseRealtimeManager
     ): ChatService
@@ -39,6 +48,11 @@ abstract class ChatModule {
     abstract fun bindChatRepository(
         impl: ChatRepositoryImpl
     ): ChatRepository
+
+    @Binds
+    abstract fun bindAiGiftAssistantService(
+        impl: FirebaseAiGiftAssistantService
+    ): AiGiftAssistantService
 
     companion object {
         @Provides

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/commons/navigation/AiGiftChatRouter.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/commons/navigation/AiGiftChatRouter.kt
@@ -1,0 +1,6 @@
+package br.com.brunocarvalhs.chat.commons.navigation
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data object AiGiftChatRouter

--- a/features/chat/src/main/res/values-de/strings.xml
+++ b/features/chat/src/main/res/values-de/strings.xml
@@ -11,4 +11,8 @@
     <string name="react_to_message">Auf Nachricht reagieren</string>
     <string name="chat_date_today">Heute</string>
     <string name="chat_date_yesterday">Gestern</string>
+    <string name="ai_gift_chat_title">Geschenkideen</string>
+    <string name="ai_gift_chat_assistant_name">Geschenk-Assistent</string>
+    <string name="ai_gift_chat_typing">Denkt nach…</string>
+    <string name="ai_gift_chat_input">Nach Geschenkideen fragen…</string>
 </resources>

--- a/features/chat/src/main/res/values-es/strings.xml
+++ b/features/chat/src/main/res/values-es/strings.xml
@@ -11,4 +11,8 @@
     <string name="react_to_message">Reaccionar al mensaje</string>
     <string name="chat_date_today">Hoy</string>
     <string name="chat_date_yesterday">Ayer</string>
+    <string name="ai_gift_chat_title">Ideas de regalo</string>
+    <string name="ai_gift_chat_assistant_name">Asistente de Regalos</string>
+    <string name="ai_gift_chat_typing">Pensando…</string>
+    <string name="ai_gift_chat_input">Pide ideas de regalo…</string>
 </resources>

--- a/features/chat/src/main/res/values-fr/strings.xml
+++ b/features/chat/src/main/res/values-fr/strings.xml
@@ -11,4 +11,8 @@
     <string name="react_to_message">Réagir au message</string>
     <string name="chat_date_today">Aujourd\'hui</string>
     <string name="chat_date_yesterday">Hier</string>
+    <string name="ai_gift_chat_title">Idées de cadeaux</string>
+    <string name="ai_gift_chat_assistant_name">Assistant Cadeaux</string>
+    <string name="ai_gift_chat_typing">Réflexion en cours…</string>
+    <string name="ai_gift_chat_input">Demandez des idées de cadeaux…</string>
 </resources>

--- a/features/chat/src/main/res/values-ko/strings.xml
+++ b/features/chat/src/main/res/values-ko/strings.xml
@@ -11,4 +11,8 @@
     <string name="react_to_message">메시지에 반응하기</string>
     <string name="chat_date_today">오늘</string>
     <string name="chat_date_yesterday">어제</string>
+    <string name="ai_gift_chat_title">선물 아이디어</string>
+    <string name="ai_gift_chat_assistant_name">선물 도우미</string>
+    <string name="ai_gift_chat_typing">생각 중…</string>
+    <string name="ai_gift_chat_input">선물 아이디어를 물어보세요…</string>
 </resources>

--- a/features/chat/src/main/res/values-nl/strings.xml
+++ b/features/chat/src/main/res/values-nl/strings.xml
@@ -11,4 +11,8 @@
     <string name="react_to_message">Reageren op bericht</string>
     <string name="chat_date_today">Vandaag</string>
     <string name="chat_date_yesterday">Gisteren</string>
+    <string name="ai_gift_chat_title">Cadeau-ideeën</string>
+    <string name="ai_gift_chat_assistant_name">Cadeau-assistent</string>
+    <string name="ai_gift_chat_typing">Aan het nadenken…</string>
+    <string name="ai_gift_chat_input">Vraag om cadeau-ideeën…</string>
 </resources>

--- a/features/chat/src/main/res/values-pl/strings.xml
+++ b/features/chat/src/main/res/values-pl/strings.xml
@@ -11,4 +11,8 @@
     <string name="react_to_message">Zareaguj na wiadomość</string>
     <string name="chat_date_today">Dzisiaj</string>
     <string name="chat_date_yesterday">Wczoraj</string>
+    <string name="ai_gift_chat_title">Pomysły na prezent</string>
+    <string name="ai_gift_chat_assistant_name">Asystent Prezentów</string>
+    <string name="ai_gift_chat_typing">Myślę…</string>
+    <string name="ai_gift_chat_input">Zapytaj o pomysły na prezent…</string>
 </resources>

--- a/features/chat/src/main/res/values-pt-rBR/strings.xml
+++ b/features/chat/src/main/res/values-pt-rBR/strings.xml
@@ -11,4 +11,8 @@
     <string name="react_to_message">Reagir à mensagem</string>
     <string name="chat_date_today">Hoje</string>
     <string name="chat_date_yesterday">Ontem</string>
+    <string name="ai_gift_chat_title">Ideias de presente</string>
+    <string name="ai_gift_chat_assistant_name">Assistente de Presentes</string>
+    <string name="ai_gift_chat_typing">Pensando…</string>
+    <string name="ai_gift_chat_input">Peça ideias de presente…</string>
 </resources>

--- a/features/chat/src/main/res/values/strings.xml
+++ b/features/chat/src/main/res/values/strings.xml
@@ -11,4 +11,8 @@
     <string name="react_to_message">React to message</string>
     <string name="chat_date_today">Today</string>
     <string name="chat_date_yesterday">Yesterday</string>
+    <string name="ai_gift_chat_title">Gift ideas</string>
+    <string name="ai_gift_chat_assistant_name">Gift Assistant</string>
+    <string name="ai_gift_chat_typing">Thinking…</string>
+    <string name="ai_gift_chat_input">Ask for gift ideas…</string>
 </resources>

--- a/features/chat/src/test/java/br/com/brunocarvalhs/chat/app/domain/usecase/StartAiGiftChatUseCaseTest.kt
+++ b/features/chat/src/test/java/br/com/brunocarvalhs/chat/app/domain/usecase/StartAiGiftChatUseCaseTest.kt
@@ -1,0 +1,34 @@
+package br.com.brunocarvalhs.chat.app.domain.usecase
+
+import br.com.brunocarvalhs.chat.app.domain.services.AiChatSession
+import br.com.brunocarvalhs.chat.app.domain.services.AiGiftAssistantService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class StartAiGiftChatUseCaseTest {
+
+    private val service: AiGiftAssistantService = mockk()
+    private lateinit var useCase: StartAiGiftChatUseCase
+
+    @Before
+    fun setup() {
+        useCase = StartAiGiftChatUseCase(service)
+    }
+
+    @Test
+    fun `invoke should start a chat session from the service using the group name`() {
+        // Given
+        val groupName = "Amigo Secreto da Família"
+        val expectedSession = mockk<AiChatSession>()
+        every { service.startChat(groupName) } returns expectedSession
+
+        // When
+        val result = useCase(groupName)
+
+        // Then
+        assertEquals(expectedSession, result)
+    }
+}

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/GroupDetailsInitializer.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/GroupDetailsInitializer.kt
@@ -30,6 +30,7 @@ class GroupDetailsInitializer(private val builder: Builder) {
                     onBack = builder.onBack,
                     onDraw = { builder.onDraw(viewModel.uiState.value.group) },
                     onChat = { builder.onChat(viewModel.uiState.value.group) },
+                    onAiGiftChat = { builder.onAiGiftChat(viewModel.uiState.value.group) },
                     onEdit = { builder.onEdit(viewModel.uiState.value.group) },
                     onAddMembers = { builder.onAddMembers(viewModel.uiState.value.group) }
                 )
@@ -42,6 +43,7 @@ class GroupDetailsInitializer(private val builder: Builder) {
         internal var onBack: () -> Unit = {}
         internal var onDraw: (GroupModel) -> Unit = {}
         internal var onChat: (GroupModel) -> Unit = {}
+        internal var onAiGiftChat: (GroupModel) -> Unit = {}
         internal var onEdit: (GroupModel) -> Unit = {}
         internal var onAddMembers: (GroupModel) -> Unit = {}
 
@@ -63,6 +65,11 @@ class GroupDetailsInitializer(private val builder: Builder) {
         @AddTrace(name = "GroupListInitializer.Builder.onChat", enabled = true)
         fun onChat(onChat: (GroupModel) -> Unit) = apply {
             this.onChat = onChat
+        }
+
+        @AddTrace(name = "GroupListInitializer.Builder.onAiGiftChat", enabled = true)
+        fun onAiGiftChat(onAiGiftChat: (GroupModel) -> Unit) = apply {
+            this.onAiGiftChat = onAiGiftChat
         }
 
         @AddTrace(name = "GroupListInitializer.Builder.onEdit", enabled = true)

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/GroupDetailsInitializerImpl.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/GroupDetailsInitializerImpl.kt
@@ -20,6 +20,9 @@ class GroupDetailsInitializerImpl @Inject constructor(
             .onChat { group ->
                 navigator.navigateToChat(navController, group)
             }
+            .onAiGiftChat { group ->
+                navigator.navigateToAiGiftChat(navController, group)
+            }
             .onEdit { group ->
                 navigator.navigateToEditGroup(navController, group)
             }

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsScreen.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.compose.material.icons.automirrored.filled.ExitToApp
 import androidx.compose.material.icons.filled.AttachMoney
+import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.CalendarToday
 import androidx.compose.material.icons.filled.CardGiftcard
 import androidx.compose.material.icons.filled.Casino
@@ -83,6 +84,7 @@ internal fun GroupDetailsScreen(
     viewModel: GroupDetailsViewModel,
     onBack: () -> Unit = {},
     onChat: (GroupModel) -> Unit = {},
+    onAiGiftChat: (GroupModel) -> Unit = {},
     onDraw: (GroupModel) -> Unit = {},
     onEdit: (GroupModel) -> Unit = {},
     onAddMembers: (GroupModel) -> Unit = {},
@@ -132,6 +134,7 @@ internal fun GroupDetailsScreen(
         onBack = onBack,
         onDraw = { onDraw.invoke(group) },
         onChat = { onChat.invoke(group) },
+        onAiGiftChat = { onAiGiftChat.invoke(group) },
         onDelete = { viewModel.handleIntent(GroupDetailsIntent.Delete(onBack)) },
         onInviteClick = { showInviteSheet = true },
         onExit = { viewModel.handleIntent(GroupDetailsIntent.Exit(onBack)) },
@@ -227,6 +230,7 @@ private fun GroupDetailsContent(
     onBack: () -> Unit,
     onDraw: () -> Unit,
     onChat: () -> Unit,
+    onAiGiftChat: () -> Unit,
     onDelete: () -> Unit,
     onExit: () -> Unit,
     onInviteClick: () -> Unit,
@@ -264,6 +268,7 @@ private fun GroupDetailsContent(
                     isDrawn = isDrawn,
                     onInviteClick = onInviteClick,
                     onChat = onChat,
+                    onAiGiftChat = onAiGiftChat,
                     onDraw = onDraw
                 )
             }
@@ -395,6 +400,7 @@ private fun GroupDetailsActions(
     isDrawn: Boolean,
     onInviteClick: () -> Unit,
     onChat: () -> Unit,
+    onAiGiftChat: () -> Unit,
     onDraw: () -> Unit
 ) {
     Column {
@@ -412,6 +418,10 @@ private fun GroupDetailsActions(
             ActionIconCard(
                 Icons.AutoMirrored.Filled.Chat,
                 stringResource(R.string.chat), onChat
+            )
+            ActionIconCard(
+                Icons.Default.AutoAwesome,
+                stringResource(R.string.ai_gift_suggestions), onAiGiftChat
             )
             ActionIconCard(
                 icon = Icons.Default.Casino,
@@ -605,6 +615,7 @@ private fun GroupDetailsPreview() {
         onDelete = {},
         onExit = {},
         onInviteClick = {},
+        onAiGiftChat = {},
         onEdit = {},
         onAddMembers = {}
     )

--- a/features/group/details/src/main/res/values-de/strings.xml
+++ b/features/group/details/src/main/res/values-de/strings.xml
@@ -12,6 +12,7 @@
     <string name="group_participants">Gruppe · %1$d Teilnehmer</string>
     <string name="invite">Einladen</string>
     <string name="chat">Chat</string>
+    <string name="ai_gift_suggestions">Geschenkideen</string>
     <string name="reveal">Aufdecken</string>
     <string name="draw">Auslosung</string>
     <string name="add_group_description">Gruppenbeschreibung hinzufügen</string>

--- a/features/group/details/src/main/res/values-es/strings.xml
+++ b/features/group/details/src/main/res/values-es/strings.xml
@@ -12,6 +12,7 @@
     <string name="group_participants">Grupo · %1$d participantes</string>
     <string name="invite">Invitar</string>
     <string name="chat">Chat</string>
+    <string name="ai_gift_suggestions">Ideas Regalo</string>
     <string name="reveal">Revelar</string>
     <string name="draw">Sorteo</string>
     <string name="add_group_description">Añadir descripción del grupo</string>

--- a/features/group/details/src/main/res/values-fr/strings.xml
+++ b/features/group/details/src/main/res/values-fr/strings.xml
@@ -12,6 +12,7 @@
     <string name="group_participants">Groupe · %1$d participants</string>
     <string name="invite">Inviter</string>
     <string name="chat">Chat</string>
+    <string name="ai_gift_suggestions">Idées Cadeau</string>
     <string name="reveal">Révéler</string>
     <string name="draw">Tirage</string>
     <string name="add_group_description">Ajouter une description du groupe</string>

--- a/features/group/details/src/main/res/values-ko/strings.xml
+++ b/features/group/details/src/main/res/values-ko/strings.xml
@@ -12,6 +12,7 @@
     <string name="group_participants">그룹 · %1$d명의 참가자</string>
     <string name="invite">초대</string>
     <string name="chat">채팅</string>
+    <string name="ai_gift_suggestions">선물 아이디어</string>
     <string name="reveal">공개</string>
     <string name="draw">추첨</string>
     <string name="add_group_description">그룹 설명 추가</string>

--- a/features/group/details/src/main/res/values-nl/strings.xml
+++ b/features/group/details/src/main/res/values-nl/strings.xml
@@ -12,6 +12,7 @@
     <string name="group_participants">Groep · %1$d deelnemers</string>
     <string name="invite">Uitnodigen</string>
     <string name="chat">Chat</string>
+    <string name="ai_gift_suggestions">Cadeau-ideeën</string>
     <string name="reveal">Onthullen</string>
     <string name="draw">Loting</string>
     <string name="add_group_description">Groepsbeschrijving toevoegen</string>

--- a/features/group/details/src/main/res/values-pl/strings.xml
+++ b/features/group/details/src/main/res/values-pl/strings.xml
@@ -12,6 +12,7 @@
     <string name="group_participants">Grupa · %1$d uczestników</string>
     <string name="invite">Zaproś</string>
     <string name="chat">Czat</string>
+    <string name="ai_gift_suggestions">Pomysły</string>
     <string name="reveal">Odkryj</string>
     <string name="draw">Losowanie</string>
     <string name="add_group_description">Dodaj opis grupy</string>

--- a/features/group/details/src/main/res/values-pt-rBR/strings.xml
+++ b/features/group/details/src/main/res/values-pt-rBR/strings.xml
@@ -12,6 +12,7 @@
     <string name="group_participants">Grupo · %1$d participantes</string>
     <string name="invite">Convidar</string>
     <string name="chat">Chat</string>
+    <string name="ai_gift_suggestions">Presente IA</string>
     <string name="reveal">Revelar</string>
     <string name="draw">Sortear</string>
     <string name="add_group_description">Adicionar descrição do grupo</string>

--- a/features/group/details/src/main/res/values/strings.xml
+++ b/features/group/details/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="group_participants">Group · %1$d participants</string>
     <string name="invite">Invite</string>
     <string name="chat">Chat</string>
+    <string name="ai_gift_suggestions">Gift Ideas</string>
     <string name="reveal">Reveal</string>
     <string name="draw">Draw</string>
     <string name="add_group_description">Add group description</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -98,6 +98,7 @@ firebase-firestore = { group = "com.google.firebase", name = "firebase-firestore
 firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
 firebase-config = { group = "com.google.firebase", name = "firebase-config" }
 firebase-database = { group = "com.google.firebase", name = "firebase-database" }
+firebase-ai = { group = "com.google.firebase", name = "firebase-ai" }
 androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "workRuntimeKtx" }
 kotlinx-coroutines-play-services = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "kotlinxCoroutinesPlayServices" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }


### PR DESCRIPTION
## Summary
- Nova opção "Sugestões IA" na tela de detalhes do grupo, ao lado de Convidar/Chat/Sorteio.
- Abre um chat com um assistente (Gemini via **Firebase AI Logic**) para pedir ideias de presente — usa o mesmo projeto Firebase do app, sem precisar gerenciar uma chave de API separada.
- Nova rota `AiGiftChatGraph`, seguindo o mesmo padrão de `ChatGraph`/`DrawGraph` (via `CommonNavigator`/`AppNavigator` e `GroupDetailsInitializer`).
- `AiGiftAssistantService` encapsula uma sessão `Chat` do Firebase AI (uma por visita à tela, com instrução de sistema + nome do grupo).
- Reaproveita o visual de balões estilo WhatsApp do chat do grupo, já nascendo com o fix de `navigationBarsPadding()`/`imePadding()`.

## ⚠️ Passo necessário no console (fora do meu alcance)
Para funcionar de verdade, é preciso habilitar a **Gemini Developer API** em **Build → AI Logic** no [Console do Firebase](https://console.firebase.google.com/) do projeto. Sem isso, o app compila e roda normalmente, mas o envio de mensagem retorna erro.

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` — compila o app inteiro sem erros (inclusive a integração real com o SDK do Firebase AI Logic)
- [x] `./gradlew :features:chat:lintDebug :features:group:details:lintDebug` — sem erros (traduzido para as 8 línguas suportadas)
- [x] `./gradlew :features:chat:testDebugUnitTest :features:group:details:testDebugUnitTest` — só as falhas pré-existentes de ambiente (Robolectric + JDK 26 local); `StartAiGiftChatUseCaseTest` novo passa
- [ ] Teste manual (depende do passo do console acima): abrir "Sugestões IA" num grupo e conversar com o assistente

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDd6WxKNjnPHjvPpiqyYN2