### PR TITLE
fix(app): initialize Firebase App Check so AI Logic requests aren't blocked

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -158,6 +158,9 @@ dependencies {
     implementation(libs.firebase.config)
     implementation(libs.firebase.analytics)
     implementation(libs.firebase.database)
+    implementation(libs.firebase.appcheck)
+    implementation(libs.firebase.appcheck.playintegrity)
+    debugImplementation(libs.firebase.appcheck.debug)
 
     // Testes
     testImplementation(libs.junit)

--- a/app/src/debug/java/br/com/brunocarvalhs/friendssecrets/initializers/AppCheckProviderFactory.kt
+++ b/app/src/debug/java/br/com/brunocarvalhs/friendssecrets/initializers/AppCheckProviderFactory.kt
@@ -1,0 +1,7 @@
+package br.com.brunocarvalhs.friendssecrets.initializers
+
+import com.google.firebase.appcheck.AppCheckProviderFactory
+import com.google.firebase.appcheck.debug.DebugAppCheckProviderFactory
+
+internal fun provideAppCheckProviderFactory(): AppCheckProviderFactory =
+    DebugAppCheckProviderFactory.getInstance()

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,6 +59,9 @@
             <meta-data
                 android:name="br.com.brunocarvalhs.friendssecrets.initializers.RealtimeInitializer"
                 android:value="androidx.startup" />
+            <meta-data
+                android:name="br.com.brunocarvalhs.friendssecrets.initializers.AppCheckInitializer"
+                android:value="androidx.startup" />
         </provider>
 
         <meta-data

--- a/app/src/main/java/br/com/brunocarvalhs/friendssecrets/initializers/AppCheckInitializer.kt
+++ b/app/src/main/java/br/com/brunocarvalhs/friendssecrets/initializers/AppCheckInitializer.kt
@@ -1,0 +1,17 @@
+package br.com.brunocarvalhs.friendssecrets.initializers
+
+import android.content.Context
+import androidx.startup.Initializer
+import com.google.firebase.Firebase
+import com.google.firebase.appcheck.appCheck
+
+class AppCheckInitializer : Initializer<Unit> {
+
+    override fun create(context: Context) {
+        Firebase.appCheck.installAppCheckProviderFactory(provideAppCheckProviderFactory())
+    }
+
+    override fun dependencies(): List<Class<out Initializer<*>?>?> {
+        return mutableListOf(FirebaseInitializer::class.java)
+    }
+}

--- a/app/src/release/java/br/com/brunocarvalhs/friendssecrets/initializers/AppCheckProviderFactory.kt
+++ b/app/src/release/java/br/com/brunocarvalhs/friendssecrets/initializers/AppCheckProviderFactory.kt
@@ -1,0 +1,7 @@
+package br.com.brunocarvalhs.friendssecrets.initializers
+
+import com.google.firebase.appcheck.AppCheckProviderFactory
+import com.google.firebase.appcheck.playintegrity.PlayIntegrityAppCheckProviderFactory
+
+internal fun provideAppCheckProviderFactory(): AppCheckProviderFactory =
+    PlayIntegrityAppCheckProviderFactory.getInstance()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -99,6 +99,9 @@ firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics
 firebase-config = { group = "com.google.firebase", name = "firebase-config" }
 firebase-database = { group = "com.google.firebase", name = "firebase-database" }
 firebase-ai = { group = "com.google.firebase", name = "firebase-ai" }
+firebase-appcheck = { group = "com.google.firebase", name = "firebase-appcheck" }
+firebase-appcheck-playintegrity = { group = "com.google.firebase", name = "firebase-appcheck-playintegrity" }
+firebase-appcheck-debug = { group = "com.google.firebase", name = "firebase-appcheck-debug" }
 androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "workRuntimeKtx" }
 kotlinx-coroutines-play-services = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "kotlinxCoroutinesPlayServices" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }


### PR DESCRIPTION
## Summary
Ao habilitar a **Gemini Developer API** no console do Firebase (para o PR #77 funcionar), o próprio Firebase ativa automaticamente a **aplicação obrigatória do App Check** para o AI Logic. O app, porém, nunca teve integração com o App Check — nenhuma chamada de IA seria aceita.

- `AppCheckInitializer` (androidx.startup), dependente do `FirebaseInitializer`, igual aos outros initializers do Firebase já existentes.
- Build de debug usa o provedor **Debug**; build de release usa **Play Integrity** — separados via source sets `debug`/`release` pra garantir que o provedor de debug (inseguro por natureza) nunca vá pra produção.

## ⚠️ Passo manual pra testar localmente
Na primeira execução de um build debug, o provedor Debug loga um token aleatório no Logcat (`AppCheck Debug Token: ...`). Esse token precisa ser registrado no [Console do Firebase](https://console.firebase.google.com/project/friends-secrets-1642275671992/appcheck) em **App Check → Apps → Friends Secrets - Android → Gerenciar tokens de depuração**, senão as chamadas continuam bloqueadas mesmo em debug.

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` — compila
- [x] `./gradlew :app:compileReleaseKotlin` — compila (confirma que os source sets debug/release resolvem certo e o provedor de debug não vaza pro release)
- [ ] Teste manual: rodar um build debug, pegar o token de debug do Logcat, registrar no console, e então testar o chat de IA (#77) de ponta a ponta

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDd6WxKNjnPHjvPpiqyYN2