### PR TITLE
fix(group-details,chat): surface action errors and use member likes for AI suggestions

### DIFF
--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/data/services/FirebaseAiGiftAssistantService.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/data/services/FirebaseAiGiftAssistantService.kt
@@ -10,17 +10,20 @@ import javax.inject.Inject
 
 class FirebaseAiGiftAssistantService @Inject constructor() : AiGiftAssistantService {
 
-    override fun startChat(groupName: String): AiChatSession {
+    override fun startChat(groupName: String, membersContext: String): AiChatSession {
         val model = Firebase.ai(backend = GenerativeBackend.googleAI()).generativeModel(
             modelName = MODEL_NAME,
             systemInstruction = content {
                 text(
                     "You are a friendly, creative gift-idea assistant inside the Friends Secrets " +
                         "Secret Santa app. The user wants gift ideas for someone in their group " +
-                        "\"$groupName\". Ask brief clarifying questions when helpful (hobbies, " +
-                        "interests, budget, age) and suggest specific, actionable, varied gift " +
-                        "ideas. Keep answers concise and always reply in the same language the " +
-                        "user writes in."
+                        "\"$groupName\". Here is what's known about the group's members, from the " +
+                        "likes/interests and adjectives they've registered in the app " +
+                        "(use this as your primary basis for suggestions when the user names one " +
+                        "of these members; ask clarifying questions when helpful, e.g. budget):\n" +
+                        membersContext + "\n\n" +
+                        "Suggest specific, actionable, varied gift ideas. Keep answers concise and " +
+                        "always reply in the same language the user writes in."
                 )
             }
         )
@@ -28,7 +31,7 @@ class FirebaseAiGiftAssistantService @Inject constructor() : AiGiftAssistantServ
     }
 
     private companion object {
-        const val MODEL_NAME = "gemini-2.5-flash"
+        const val MODEL_NAME = "gemini-3.7-flash"
     }
 }
 

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/domain/services/AiGiftAssistantService.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/domain/services/AiGiftAssistantService.kt
@@ -1,7 +1,7 @@
 package br.com.brunocarvalhs.chat.app.domain.services
 
 interface AiGiftAssistantService {
-    fun startChat(groupName: String): AiChatSession
+    fun startChat(groupName: String, membersContext: String): AiChatSession
 }
 
 interface AiChatSession {

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/domain/usecase/StartAiGiftChatUseCase.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/domain/usecase/StartAiGiftChatUseCase.kt
@@ -7,5 +7,6 @@ import javax.inject.Inject
 class StartAiGiftChatUseCase @Inject constructor(
     private val service: AiGiftAssistantService
 ) {
-    operator fun invoke(groupName: String): AiChatSession = service.startChat(groupName)
+    operator fun invoke(groupName: String, membersContext: String): AiChatSession =
+        service.startChat(groupName, membersContext)
 }

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/AiGiftChatIntent.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/AiGiftChatIntent.kt
@@ -3,4 +3,5 @@ package br.com.brunocarvalhs.chat.app.presentation
 internal sealed interface AiGiftChatIntent {
     data class UpdateInput(val text: String) : AiGiftChatIntent
     data object SendMessage : AiGiftChatIntent
+    data object DismissError : AiGiftChatIntent
 }

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/AiGiftChatScreen.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/AiGiftChatScreen.kt
@@ -30,6 +30,8 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -39,6 +41,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -56,6 +59,7 @@ internal fun AiGiftChatScreen(
 ) {
     val state by viewModel.uiState.collectAsState()
     val listState = rememberLazyListState()
+    val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(state.messages.size, state.isLoading) {
         if (state.messages.isNotEmpty()) {
@@ -63,7 +67,15 @@ internal fun AiGiftChatScreen(
         }
     }
 
+    LaunchedEffect(state.error) {
+        state.error?.let { message ->
+            snackbarHostState.showSnackbar(message)
+            viewModel.handleIntent(AiGiftChatIntent.DismissError)
+        }
+    }
+
     Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.ai_gift_chat_title)) },

--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/AiGiftChatViewModel.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/presentation/AiGiftChatViewModel.kt
@@ -10,6 +10,7 @@ import br.com.brunocarvalhs.chat.app.domain.services.AiChatSession
 import br.com.brunocarvalhs.chat.app.domain.usecase.StartAiGiftChatUseCase
 import br.com.brunocarvalhs.core.analytics.AnalyticsService
 import br.com.brunocarvalhs.core.analytics.commons.AnalyticsEvent
+import br.com.brunocarvalhs.core.domain.model.UserModel
 import br.com.brunocarvalhs.core.navigation.routers.AiGiftChatGraph
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -27,7 +28,10 @@ internal class AiGiftChatViewModel @Inject constructor(
     private val analyticsService: AnalyticsService
 ) : ViewModel() {
     private val args = savedStateHandle.toRoute<AiGiftChatGraph>(AiGiftChatGraph.typeMap)
-    private val session: AiChatSession = startAiGiftChatUseCase(args.group.name)
+    private val session: AiChatSession = startAiGiftChatUseCase(
+        args.group.name,
+        buildMembersContext(args.group.members)
+    )
 
     private val _uiState = MutableStateFlow(
         AiGiftChatUiState(
@@ -53,6 +57,7 @@ internal class AiGiftChatViewModel @Inject constructor(
         when (intent) {
             is AiGiftChatIntent.UpdateInput -> _uiState.update { it.copy(inputText = intent.text) }
             is AiGiftChatIntent.SendMessage -> sendMessage()
+            is AiGiftChatIntent.DismissError -> _uiState.update { it.copy(error = null) }
         }
     }
 
@@ -93,9 +98,31 @@ internal class AiGiftChatViewModel @Inject constructor(
         }
     }
 
+    private fun buildMembersContext(members: List<UserModel>): String {
+        if (members.isEmpty()) return NO_MEMBERS_CONTEXT
+
+        return members.joinToString(separator = "\n") { member ->
+            val likes = member.likes.filter { it.isNotBlank() }
+            val adjectives = member.adjectives.values.flatten().distinct()
+
+            val likesText = likes.ifEmpty { null }?.joinToString(", ")
+            val adjectivesText = adjectives.ifEmpty { null }?.joinToString(", ")
+
+            when {
+                likesText != null && adjectivesText != null ->
+                    "- ${member.name}: gosta de $likesText (descrito como $adjectivesText)"
+
+                likesText != null -> "- ${member.name}: gosta de $likesText"
+                adjectivesText != null -> "- ${member.name}: descrito como $adjectivesText"
+                else -> "- ${member.name}: sem gostos ou adjetivos registrados ainda"
+            }
+        }
+    }
+
     private companion object {
         const val INITIAL_GREETING =
             "Oi! 👋 Me conta um pouco sobre a pessoa que você quer presentear: " +
                 "hobbies, gostos, uma faixa de preço... e eu te ajudo com ideias de presente!"
+        const val NO_MEMBERS_CONTEXT = "Nenhum membro com gostos ou adjetivos registrados ainda."
     }
 }

--- a/features/chat/src/test/java/br/com/brunocarvalhs/chat/app/domain/usecase/StartAiGiftChatUseCaseTest.kt
+++ b/features/chat/src/test/java/br/com/brunocarvalhs/chat/app/domain/usecase/StartAiGiftChatUseCaseTest.kt
@@ -19,14 +19,15 @@ class StartAiGiftChatUseCaseTest {
     }
 
     @Test
-    fun `invoke should start a chat session from the service using the group name`() {
+    fun `invoke should start a chat session from the service using the group name and context`() {
         // Given
         val groupName = "Amigo Secreto da Família"
+        val membersContext = "- Bruno: Livros, Jogos"
         val expectedSession = mockk<AiChatSession>()
-        every { service.startChat(groupName) } returns expectedSession
+        every { service.startChat(groupName, membersContext) } returns expectedSession
 
         // When
-        val result = useCase(groupName)
+        val result = useCase(groupName, membersContext)
 
         // Then
         assertEquals(expectedSession, result)

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsIntent.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsIntent.kt
@@ -12,4 +12,5 @@ internal sealed interface GroupDetailsIntent {
     data class RemoveMember(val memberId: String) : GroupDetailsIntent
     data class UpdateLikes(val likes: List<String>) : GroupDetailsIntent
     data class AddAdjective(val memberId: String, val adjective: String) : GroupDetailsIntent
+    data object DismissError : GroupDetailsIntent
 }

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsScreen.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsScreen.kt
@@ -38,12 +38,15 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -96,6 +99,14 @@ internal fun GroupDetailsScreen(
     var editingLikesMember by remember { mutableStateOf<UserModel?>(null) }
     var addingAdjectiveMember by remember { mutableStateOf<UserModel?>(null) }
     var showInviteSheet by remember { mutableStateOf(false) }
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(uiState.error) {
+        uiState.error?.let { message ->
+            snackbarHostState.showSnackbar(message)
+            viewModel.handleIntent(GroupDetailsIntent.DismissError)
+        }
+    }
 
     val notificationPermissionState = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         rememberPermissionState(Manifest.permission.POST_NOTIFICATIONS)
@@ -153,7 +164,8 @@ internal fun GroupDetailsScreen(
         onRemoveMember = { member -> memberPendingRemoval = member },
         onShareWishlist = { viewModel.handleIntent(GroupDetailsIntent.ShareWishlist) },
         onEditLikes = { member -> editingLikesMember = member },
-        onAddAdjective = { member -> addingAdjectiveMember = member }
+        onAddAdjective = { member -> addingAdjectiveMember = member },
+        snackbarHostState = snackbarHostState
     )
 
     memberPendingRemoval?.let { member ->
@@ -243,11 +255,13 @@ private fun GroupDetailsContent(
     currentDeviceId: String = "",
     onEditLikes: (UserModel) -> Unit = {},
     onAddAdjective: (UserModel) -> Unit = {},
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
     Scaffold(
         topBar = {
             GroupDetailsTopBar(onBack = onBack)
-        }
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
     ) { paddingValue ->
         LazyColumn(
             modifier = Modifier

--- a/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsViewModel.kt
+++ b/features/group/details/src/main/java/br/com/brunocarvalhs/group/details/app/presentation/GroupDetailsViewModel.kt
@@ -74,6 +74,7 @@ internal class GroupDetailsViewModel @Inject constructor(
         GroupDetailsIntent.ShareWishlist -> shareWishlist()
         is GroupDetailsIntent.UpdateLikes -> updateLikes(intent.likes)
         is GroupDetailsIntent.AddAdjective -> addAdjective(intent.memberId, intent.adjective)
+        is GroupDetailsIntent.DismissError -> _uiState.update { it.copy(error = null) }
     }
 
     private fun loadReminderState() {


### PR DESCRIPTION
## Summary

**1. Compartilhar lista de desejos "não funcionava"**
O `ShareWishlistUseCase` já falhava corretamente quando o usuário não tinha nenhum "gosto" cadastrado (ou não era membro do grupo), mas o `error` da ViewModel nunca era exibido em lugar nenhum — a falha era 100% silenciosa. Isso afetava TODAS as ações que podem falhar nessa tela (compartilhar wishlist, apagar grupo, sair do grupo, remover membro, editar gostos, adicionar adjetivo, lembrete) e também o chat de IA. Agora ambas as telas mostram um Snackbar com a mensagem de erro.

**2. Adjetivos vs. gostos para a IA**
Conforme esclarecido: a intenção original era a IA usar os **gostos** de cada membro para basear as sugestões de presente, não uma feature de adjetivos isolada. O chat de IA agora monta um resumo dos gostos (e adjetivos, como contexto extra) de cada membro do grupo e injeta isso na instrução de sistema do Gemini — então perguntar "o que dar pra Isabella?" já usa o que ela cadastrou.

**3. Bônus: 404 no modelo do Gemini**
O modelo `gemini-2.5-flash` está sendo descontinuado e retornava 404. Troquei para `gemini-3.7-flash` (atual, estável, sem faturamento).

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` — compila
- [x] `./gradlew :features:chat:testDebugUnitTest :features:group:details:testDebugUnitTest` — só as falhas pré-existentes de ambiente (Robolectric + JDK 26 local); `StartAiGiftChatUseCaseTest` atualizado passa
- [ ] Teste manual: tentar compartilhar wishlist sem nenhum gosto cadastrado (deve mostrar erro agora); perguntar à IA sobre um membro com gostos cadastrados

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDd6WxKNjnPHjvPpiqyYN2