### PR TITLE
fix(chat): use OpenRouter's Free Models Router instead of a pinned model

### DIFF
--- a/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/data/services/OpenRouterAiGiftAssistantService.kt
+++ b/features/chat/src/main/java/br/com/brunocarvalhs/chat/app/data/services/OpenRouterAiGiftAssistantService.kt
@@ -89,7 +89,7 @@ private class OpenRouterChatSession(
 
     private companion object {
         const val CHAT_COMPLETIONS_URL = "https://openrouter.ai/api/v1/chat/completions"
-        const val MODEL_NAME = "meta-llama/llama-3.3-70b-instruct:free"
+        const val MODEL_NAME = "openrouter/free"
         const val ROLE_SYSTEM = "system"
         const val ROLE_USER = "user"
         const val ROLE_ASSISTANT = "assistant"


### PR DESCRIPTION
## Summary
Troca o model id de `meta-llama/llama-3.3-70b-instruct:free` (fixo) para `openrouter/free` — o **Free Models Router** da OpenRouter, que escolhe automaticamente entre os modelos gratuitos disponíveis, filtrando por recursos necessários (tool calling, etc). Mais resiliente: se um modelo gratuito específico for descontinuado ou ficar rate-limited, o chat continua funcionando.

- Model ID: `openrouter/free`
- Context window: 200k tokens
- Custo: zero (prompt e completion)
- Sem parâmetros especiais além da chamada normal de chat completions

## Test plan
- [x] `./gradlew :features:chat:compileDebugKotlin` — compila
- [ ] Teste manual: conversar no chat de IA e confirmar resposta

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDd6WxKNjnPHjvPpiqyYN2