### PR TITLE
feat(flags): wire real Remote Config toggles for home and settings

### DIFF
--- a/features/group/list/src/main/java/br/com/brunocarvalhs/group/list/GroupListInitializerImpl.kt
+++ b/features/group/list/src/main/java/br/com/brunocarvalhs/group/list/GroupListInitializerImpl.kt
@@ -7,11 +7,13 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import br.com.brunocarvalhs.core.navigation.CommonNavigator
 import br.com.brunocarvalhs.core.navigation.FeatureInitializer
+import br.com.brunocarvalhs.core.remote.domain.FeatureFlagService
 import br.com.brunocarvalhs.group.list.commons.options.OptionsMore
 import javax.inject.Inject
 
 class GroupListInitializerImpl @Inject constructor(
-    private val navigator: CommonNavigator
+    private val navigator: CommonNavigator,
+    private val featureFlagService: FeatureFlagService
 ) : FeatureInitializer {
 
     override fun register(navGraphBuilder: NavGraphBuilder, navController: NavHostController) {
@@ -20,18 +22,25 @@ class GroupListInitializerImpl @Inject constructor(
             .onGroupToCreate { navigator.navigateToGroupCreate(navController) }
             .onGroupToDetails { navigator.navigateToGroupDetails(navController, it) }
             .setMoreOptions(
-                listOf(
-                    OptionsMore(
-                    lambda = { navigator.navigateToSettings(navController) },
-                    icon = Icons.Default.Settings,
-                    contentDescription = {
-                        stringResource(R.string.title_settings)
-                    },
-                    name = {
-                        stringResource(R.string.title_settings)
+                listOfNotNull(
+                    if (featureFlagService.validate(FEATURE_SETTINGS, true)) {
+                        OptionsMore(
+                            lambda = { navigator.navigateToSettings(navController) },
+                            icon = Icons.Default.Settings,
+                            contentDescription = {
+                                stringResource(R.string.title_settings)
+                            },
+                            name = {
+                                stringResource(R.string.title_settings)
+                            }
+                        )
+                    } else {
+                        null
                     }
-                ),
-            ))
+                )
+            )
             .build(navGraphBuilder)
     }
 }
+
+private const val FEATURE_SETTINGS = "settings_is_enabled"

--- a/features/group/list/src/main/java/br/com/brunocarvalhs/group/list/app/presentation/GroupListScreen.kt
+++ b/features/group/list/src/main/java/br/com/brunocarvalhs/group/list/app/presentation/GroupListScreen.kt
@@ -94,6 +94,7 @@ private fun ListContent(
                     GroupListAppBar(
                         scrollBehavior = scrollBehavior,
                         onJoinGroupClick = { showBottomSheet = true; onJoinGroupOpen() },
+                        isJoinGroupEnabled = uiState.isJoinGroupEnabled,
                         moreOptions = moreOptions,
                         expanded = expanded,
                         onExpandedChange = { expanded = it }
@@ -113,7 +114,9 @@ private fun ListContent(
             }
         },
         floatingActionButton = {
-            GroupListFab(onGroupToCreate = onGroupToCreate)
+            if (uiState.isCreateGroupEnabled) {
+                GroupListFab(onGroupToCreate = onGroupToCreate)
+            }
         }
     ) { paddingValues ->
         GroupListContent(
@@ -165,7 +168,9 @@ private fun GroupListContent(
                 if (uiState.filteredList.isEmpty() && !uiState.isLoading) {
                     EmptyGroupComponent(
                         onGroupToEnter = onJoinGroupClick,
-                        onCreateGroup = onGroupToCreate
+                        onCreateGroup = onGroupToCreate,
+                        isJoinGroupEnabled = uiState.isJoinGroupEnabled,
+                        isCreateGroupEnabled = uiState.isCreateGroupEnabled
                     )
                 } else {
                     GroupListItems(

--- a/features/group/list/src/main/java/br/com/brunocarvalhs/group/list/app/presentation/GroupListUiState.kt
+++ b/features/group/list/src/main/java/br/com/brunocarvalhs/group/list/app/presentation/GroupListUiState.kt
@@ -24,7 +24,9 @@ internal data class GroupListUiState(
     val list: List<GroupModel> = emptyList(),
     val errorMessage: String? = null,
     val searchQuery: String = EMPTY_STRING,
-    val selectedTag: GroupFilterTag = GroupFilterTag.ACTIVE
+    val selectedTag: GroupFilterTag = GroupFilterTag.ACTIVE,
+    val isCreateGroupEnabled: Boolean = true,
+    val isJoinGroupEnabled: Boolean = true
 ) {
     val tags: List<GroupFilterTag> = GroupFilterTag.entries
 

--- a/features/group/list/src/main/java/br/com/brunocarvalhs/group/list/app/presentation/GroupListViewModel.kt
+++ b/features/group/list/src/main/java/br/com/brunocarvalhs/group/list/app/presentation/GroupListViewModel.kt
@@ -11,6 +11,7 @@ import br.com.brunocarvalhs.core.domain.model.GroupModel
 import br.com.brunocarvalhs.core.navigation.DeepLinkHandler
 import br.com.brunocarvalhs.group.list.app.domain.useCases.GroupByTokenUseCase
 import br.com.brunocarvalhs.group.list.app.domain.useCases.GroupListUseCase
+import br.com.brunocarvalhs.group.list.commons.flags.GroupListFeatureFlags
 import com.google.firebase.perf.metrics.AddTrace
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -28,9 +29,15 @@ internal class GroupListViewModel @Inject constructor(
     private val groupByTokenUseCase: GroupByTokenUseCase,
     private val analyticsService: AnalyticsService,
     private val deepLinkHandler: DeepLinkHandler,
+    private val featureFlags: GroupListFeatureFlags,
 ) : ViewModel() {
 
-    private val _uiState = MutableStateFlow(GroupListUiState())
+    private val _uiState = MutableStateFlow(
+        GroupListUiState(
+            isCreateGroupEnabled = featureFlags.isCreateGroupEnabled(),
+            isJoinGroupEnabled = featureFlags.isJoinGroupEnabled()
+        )
+    )
     val uiState: StateFlow<GroupListUiState> = _uiState.asStateFlow()
 
     init {

--- a/features/group/list/src/main/java/br/com/brunocarvalhs/group/list/app/presentation/components/GroupListAppBar.kt
+++ b/features/group/list/src/main/java/br/com/brunocarvalhs/group/list/app/presentation/components/GroupListAppBar.kt
@@ -27,6 +27,7 @@ internal fun GroupListAppBar(
     moreOptions: List<OptionsMore>,
     expanded: Boolean,
     onExpandedChange: (Boolean) -> Unit,
+    isJoinGroupEnabled: Boolean = true,
 ) {
     TopAppBar(
         title = { Text("Friends Secrets", style = MaterialTheme.typography.titleLarge) },
@@ -34,11 +35,13 @@ internal fun GroupListAppBar(
             containerColor = Color.Companion.Transparent
         ),
         actions = {
-            IconButton(onClick = onJoinGroupClick) {
-                Icon(
-                    Icons.Default.GroupAdd,
-                    contentDescription = stringResource(R.string.join_group)
-                )
+            if (isJoinGroupEnabled) {
+                IconButton(onClick = onJoinGroupClick) {
+                    Icon(
+                        Icons.Default.GroupAdd,
+                        contentDescription = stringResource(R.string.join_group)
+                    )
+                }
             }
 
             if (moreOptions.isNotEmpty()) {

--- a/features/group/list/src/main/java/br/com/brunocarvalhs/group/list/commons/flags/GroupListFeatureFlags.kt
+++ b/features/group/list/src/main/java/br/com/brunocarvalhs/group/list/commons/flags/GroupListFeatureFlags.kt
@@ -8,9 +8,9 @@ import javax.inject.Singleton
 internal class GroupListFeatureFlags @Inject constructor(
     private val service: FeatureFlagService
 ) {
-    fun isListEnabled(): Boolean = service.validate(FEATURE_GROUP_LIST, true)
-    fun isBannerEnabled(): Boolean = service.validate(FEATURE_GROUP_LIST_BANNER, true)
+    fun isCreateGroupEnabled(): Boolean = service.validate(FEATURE_CREATE_GROUP, true)
+    fun isJoinGroupEnabled(): Boolean = service.validate(FEATURE_JOIN_GROUP, true)
 }
 
-private const val FEATURE_GROUP_LIST = "feature_group_list_enabled"
-private const val FEATURE_GROUP_LIST_BANNER = "feature_group_list_banner_enabled"
+private const val FEATURE_CREATE_GROUP = "home_is_create_group_enabled"
+private const val FEATURE_JOIN_GROUP = "home_is_join_group_enabled"

--- a/features/settings/src/main/java/br/com/brunocarvalhs/settings/app/list/SettingsScreen.kt
+++ b/features/settings/src/main/java/br/com/brunocarvalhs/settings/app/list/SettingsScreen.kt
@@ -55,7 +55,8 @@ internal fun SettingsScreen(
 
     SettingsContent(
         isBiometricPromptEnabled = state.isBiometricPromptEnabled,
-        isBiometricSupported = state.isBiometricSupported,
+        isBiometricSupported = state.isBiometricSupported && state.isFingerprintFeatureEnabled,
+        isAppearanceEnabled = state.isAppearanceEnabled,
         versionName = state.versionName,
         versionCode = state.versionCode,
         onBack = onBack,
@@ -73,6 +74,7 @@ internal fun SettingsScreen(
 private fun SettingsContent(
     isBiometricPromptEnabled: Boolean = false,
     isBiometricSupported: Boolean = false,
+    isAppearanceEnabled: Boolean = true,
     versionName: String = "",
     versionCode: String = "",
     onBack: () -> Unit = {},
@@ -114,6 +116,7 @@ private fun SettingsContent(
             GeneralSection(
                 isBiometricSupported = isBiometricSupported,
                 isBiometricPromptEnabled = isBiometricPromptEnabled,
+                isAppearanceEnabled = isAppearanceEnabled,
                 onBiometricPrompt = onBiometricPrompt,
                 onAppearance = onAppearance
             )
@@ -150,6 +153,7 @@ private fun SettingsContent(
 private fun GeneralSection(
     isBiometricSupported: Boolean,
     isBiometricPromptEnabled: Boolean,
+    isAppearanceEnabled: Boolean,
     onBiometricPrompt: (Boolean) -> Unit,
     onAppearance: () -> Unit
 ) {
@@ -166,11 +170,13 @@ private fun GeneralSection(
                 onClick = onBiometricPrompt
             )
         }
-        SettingsListItemNavigation(
-            title = R.string.title_appearance,
-            icon = Icons.Outlined.Palette,
-            onClick = onAppearance
-        )
+        if (isAppearanceEnabled) {
+            SettingsListItemNavigation(
+                title = R.string.title_appearance,
+                icon = Icons.Outlined.Palette,
+                onClick = onAppearance
+            )
+        }
     }
 }
 

--- a/features/settings/src/main/java/br/com/brunocarvalhs/settings/app/list/SettingsState.kt
+++ b/features/settings/src/main/java/br/com/brunocarvalhs/settings/app/list/SettingsState.kt
@@ -3,6 +3,8 @@ package br.com.brunocarvalhs.settings.app.list
 internal data class SettingsState(
     val isBiometricPromptEnabled: Boolean = false,
     val isBiometricSupported: Boolean = false,
+    val isAppearanceEnabled: Boolean = true,
+    val isFingerprintFeatureEnabled: Boolean = true,
     val versionName: String = "",
     val versionCode: String = ""
 )

--- a/features/settings/src/main/java/br/com/brunocarvalhs/settings/app/list/SettingsViewModel.kt
+++ b/features/settings/src/main/java/br/com/brunocarvalhs/settings/app/list/SettingsViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.viewModelScope
 import br.com.brunocarvalhs.biometric.BiometricService
 import br.com.brunocarvalhs.core.analytics.AnalyticsService
 import br.com.brunocarvalhs.core.analytics.commons.AnalyticsEvent
+import br.com.brunocarvalhs.settings.commons.flags.SettingsFeatureFlags
 import com.google.firebase.perf.metrics.AddTrace
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -22,10 +23,16 @@ import javax.inject.Inject
 internal class SettingsViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val biometricService: BiometricService,
-    private val analyticsService: AnalyticsService
+    private val analyticsService: AnalyticsService,
+    private val featureFlags: SettingsFeatureFlags
 ) : ViewModel() {
 
-    private val _state = MutableStateFlow(SettingsState())
+    private val _state = MutableStateFlow(
+        SettingsState(
+            isAppearanceEnabled = featureFlags.isAppearanceEnabled(),
+            isFingerprintFeatureEnabled = featureFlags.isFingerprintEnabled()
+        )
+    )
     val state = _state.asStateFlow()
 
     init {

--- a/features/settings/src/main/java/br/com/brunocarvalhs/settings/commons/flags/SettingsFeatureFlags.kt
+++ b/features/settings/src/main/java/br/com/brunocarvalhs/settings/commons/flags/SettingsFeatureFlags.kt
@@ -8,11 +8,13 @@ import javax.inject.Singleton
 internal class SettingsFeatureFlags @Inject constructor(
     private val service: FeatureFlagService
 ) {
-    fun isSettingsEnabled(): Boolean = service.validate(FEATURE_SETTINGS, true)
+    fun isAppearanceEnabled(): Boolean = service.validate(FEATURE_SETTINGS_APPEARANCE, true)
+    fun isFingerprintEnabled(): Boolean = service.validate(FEATURE_SETTINGS_FINGERPRINT, true)
     fun isReportIssueEnabled(): Boolean = service.validate(FEATURE_SETTINGS_REPORT_ISSUE, true)
     fun isFaqEnabled(): Boolean = service.validate(FEATURE_SETTINGS_FAQ, true)
 }
 
-private const val FEATURE_SETTINGS = "feature_settings_enabled"
-private const val FEATURE_SETTINGS_REPORT_ISSUE = "feature_settings_report_issue_enabled"
-private const val FEATURE_SETTINGS_FAQ = "feature_settings_faq_enabled"
+private const val FEATURE_SETTINGS_APPEARANCE = "settings_is_appearance_enabled"
+private const val FEATURE_SETTINGS_FINGERPRINT = "settings_is_fingerprint_enabled"
+private const val FEATURE_SETTINGS_REPORT_ISSUE = "settings_is_report_issue_enabled"
+private const val FEATURE_SETTINGS_FAQ = "settings_is_faq_enabled"


### PR DESCRIPTION
## Summary
- Replaces the unused `feature_*_enabled` key names in the group-list and settings flag wrapper classes with the actual keys already configured in the Firebase console's `features_toggles` parameter group.
- Wires 5 of the 8 toggles to real UI:
  - `home_is_create_group_enabled` — create-group FAB + empty-state button
  - `home_is_join_group_enabled` — app bar join icon + empty-state button
  - `settings_is_enabled` — Settings entry in the group list overflow menu
  - `settings_is_appearance_enabled` — Appearance nav item
  - `settings_is_fingerprint_enabled` — combined with device biometric support to gate the security switch
- `settings_is_report_issue_enabled` / `settings_is_faq_enabled` are left defined with the correct keys but unwired, since Settings currently has no buttons pointing at those already-registered destinations.
- `app_is_theme_remote` intentionally left out — no existing concept in the codebase for it, needs a decision from @brunocarvalhs on what it should actually do.

## Test plan
- [x] `:features:group:list:compileDebugKotlin` / `:features:settings:compileDebugKotlin` — success
- [x] `:app:compileDebugKotlin` (Hilt graph) — success
- [x] `:features:group:list:testDebugUnitTest` / `:features:settings:testDebugUnitTest` — success
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDd6WxKNjnPHjvPpiqyYN2